### PR TITLE
Some possible Coxeter (interface) definitons

### DIFF
--- a/Pi+/Conjectures.agda
+++ b/Pi+/Conjectures.agda
@@ -11,19 +11,19 @@ open import lib.types.Fin
 open import lib.types.Truncation
 open import lib.NType2
 
-⟦_⟧₀ : U → UFin
-⟦ X ⟧₀ = FinFS ∣ X ∣
+-- ⟦_⟧₀ : U → UFin
+-- ⟦ X ⟧₀ = FinFS ∣ X ∣
 
-⌜_⌝₀ : UFin → U
-⌜ X ⌝₀ = ⟪ card X ⟫
+-- ⌜_⌝₀ : UFin → U
+-- ⌜ X ⌝₀ = ⟪ card X ⟫
 
-⌜⟦_⟧⌝₀ : (X : U) → ⌜ ⟦ X ⟧₀ ⌝₀ ⟷₁ X
-⌜⟦ O ⟧⌝₀ = id⟷₁
-⌜⟦ I ⟧⌝₀ = swap₊ ◎ unite₊l
-⌜⟦ X + Y ⟧⌝₀ = !⟷₁ (normC (X + Y))
+-- ⌜⟦_⟧⌝₀ : (X : U) → ⌜ ⟦ X ⟧₀ ⌝₀ ⟷₁ X
+-- ⌜⟦ O ⟧⌝₀ = id⟷₁
+-- ⌜⟦ I ⟧⌝₀ = swap₊ ◎ unite₊l
+-- ⌜⟦ X + Y ⟧⌝₀ = !⟷₁ (normC (X + Y))
 
-⟦⌜_⌝⟧₀ : (X : UFin) → Trunc -1 (⟦ ⌜ X ⌝₀ ⟧₀ == X)
-⟦⌜_⌝⟧₀ = FinSet-elim-prop (λ _ → Trunc-level) λ n → [ pair= (ap Fin ∣⟪ n ⟫∣) prop-has-all-paths-↓ ]
+-- ⟦⌜_⌝⟧₀ : (X : UFin) → Trunc -1 (⟦ ⌜ X ⌝₀ ⟧₀ == X)
+-- ⟦⌜_⌝⟧₀ = FinSet-elim-prop (λ _ → Trunc-level) λ n → [ pair= (ap Fin ∣⟪ n ⟫∣) prop-has-all-paths-↓ ]
 
 -- ⟦_⟧₁ : {X Y : U} → X ⟷₁ Y → ⟦ X ⟧₀ == ⟦ Y ⟧₀ {- Lehmer n -}
 -- ⟦ p ⟧₁ = {!   !}

--- a/Pi+/Conjectures.agda
+++ b/Pi+/Conjectures.agda
@@ -5,45 +5,47 @@ module Pi+.Conjectures where
 open import Pi+.Syntax as Pi
 open import Pi+.UFin
 open import Pi+.Level0
+open import Pi+.Extra
 
 open import lib.Basics
 open import lib.types.Fin
 open import lib.types.Truncation
 open import lib.NType2
 
--- ⟦_⟧₀ : U → UFin
--- ⟦ X ⟧₀ = FinFS ∣ X ∣
+eval₀ : U → UFin
+eval₀ X = FinFS ∣ X ∣
 
--- ⌜_⌝₀ : UFin → U
--- ⌜ X ⌝₀ = ⟪ card X ⟫
+quote₀ : UFin → U
+quote₀ X = ⟪ card X ⟫
 
--- ⌜⟦_⟧⌝₀ : (X : U) → ⌜ ⟦ X ⟧₀ ⌝₀ ⟷₁ X
--- ⌜⟦ O ⟧⌝₀ = id⟷₁
--- ⌜⟦ I ⟧⌝₀ = swap₊ ◎ unite₊l
--- ⌜⟦ X + Y ⟧⌝₀ = !⟷₁ (normC (X + Y))
+quote-eval₀ : (X : U) → quote₀ (eval₀ X) ⟷₁ X
+quote-eval₀ O = id⟷₁
+quote-eval₀ I = swap₊ ◎ unite₊l
+quote-eval₀ (X + Y) = !⟷₁ TODO -- (normC (X + Y))
 
--- ⟦⌜_⌝⟧₀ : (X : UFin) → Trunc -1 (⟦ ⌜ X ⌝₀ ⟧₀ == X)
--- ⟦⌜_⌝⟧₀ = FinSet-elim-prop (λ _ → Trunc-level) λ n → [ pair= (ap Fin ∣⟪ n ⟫∣) prop-has-all-paths-↓ ]
+eval-quote₀ : (X : UFin) → Trunc -1 (eval₀ (quote₀ X) == X)
+eval-quote₀ = FinSet-elim-prop (λ _ → Trunc-level) λ n → [ pair= (ap Fin TODO) prop-has-all-paths-↓ ]
 
--- ⟦_⟧₁ : {X Y : U} → X ⟷₁ Y → ⟦ X ⟧₀ == ⟦ Y ⟧₀ {- Lehmer n -}
--- ⟦ p ⟧₁ = {!   !}
+eval₁ : {X Y : U} → X ⟷₁ Y → eval₀ X == eval₀ Y
+eval₁ p = TODO
 
--- ⌜_⌝₁ : {X Y : UFin} → X == Y → ⌜ X ⌝₀ ⟷₁ ⌜ Y ⌝₀
--- ⌜_⌝₁ = {!   !}
+quote₁ : {X Y : UFin} → X == Y → quote₀ X ⟷₁ quote₀ Y
+quote₁ = TODO
 
--- ⌜⟦_⟧⌝₁ : {X Y : U} → (p : X ⟷₁ Y) → ⌜ ⟦ p ⟧₁ ⌝₁ ⟷₂ p
--- ⌜⟦ p ⟧⌝₁ = {!   !}
+quote-eval₁ : {X Y : U} → (p : X ⟷₁ Y) → quote₁ (eval₁ p) ⟷₂ (quote-eval₀ X ◎ p ◎ !⟷₁ (quote-eval₀ Y))
+quote-eval₁ p = TODO
 
--- ⟦⌜_⌝⟧₁ : {X Y : UFin} → (p : X == Y) → ⟦ ⌜ p ⌝₁ ⟧₁ == p
+eval-quote₁ : {X Y : UFin} → (p : X == Y) → eval₁ (quote₁ p) == ap (λ X → eval₀ (quote₀ X)) p
+eval-quote₁ p = TODO
 
--- ⟦_⟧₂ : {X Y : U} → {p q : X ⟷₁ Y } → p ⟷₂ q → ⟦ p ⟧₁ == ⟦ q ⟧₁
--- ⟦ α ⟧₂ = {!   !}
+eval₂ : {X Y : U} {p q : X ⟷₁ Y } → p ⟷₂ q → eval₁ p == eval₁ q
+eval₂ α = TODO
 
--- ⌜_⌝₂ : {X Y : UFin} {p q : X == Y} (α : p == q) → ⌜ p ⌝₁ ⟷₂ ⌜ q ⌝₁
--- ⌜ idp ⌝₂ = id⟷₂
+quote₂ : {X Y : UFin} {p q : X == Y} (α : p == q) → quote₁ p ⟷₂ quote₁ q
+quote₂ α = TODO
 
--- ⟦⌜_⌝⟧₂ : {X Y : UFin} {p q : X == Y} (α : p == q) → ⟦ ⌜ α ⌝₂ ⟧₂ == α
--- ⟦⌜ α ⌝⟧₂ = prop-has-all-paths (ap ((⟦_⟧₁ ∘ ⌜_⌝₁)) α) ((ap ((⟦_⟧₁ ∘ ⌜_⌝₁)) α))
+quote-eval₂ : {X Y : U} {p q : X ⟷₁ Y } (α : p ⟷₂ q) → quote₂ (eval₂ α) ⟷₃ trans⟷₂ (quote-eval₁ p) TODO
+quote-eval₂ α = TODO
 
--- ⌜⟦_⟧⌝₂ : {X Y : UFin} {p q : X == Y} (α : p == q) → ⌜ ⟦ α ⟧₂ ⌝₂ ⟷₃ α
--- ⌜⟦ α ⟧⌝₂ = trunc
+eval-quote₂ : {X Y : UFin} {p q : X == Y} (α : p == q) → eval₂ (quote₂ α) == TODO
+eval-quote₂ α = TODO

--- a/Pi+/Coxeter/Arithmetic.agda
+++ b/Pi+/Coxeter/Arithmetic.agda
@@ -133,10 +133,17 @@ postulate
     ≤-down-+ : {p q r : ℕ} -> (p + r ≤ q) -> (p ≤ q)
     ≡-down-+ : {p q r : ℕ} -> (r + p == r + q) -> (p == q)
     ≡-down-r-+ : {p q r : ℕ} -> (p + r == q + r) -> (p == q)
-    ∸-anti-≤ : {p q r : ℕ} -> (q ≤ p) -> (p ≤ r) -> (r ∸ p) ≤ (r ∸ q)
     ≤-≡ : {n k : ℕ} -> (n ≤ k) -> (k ≤ n) -> (n == k)
     plus-minus : {p q : ℕ} -> (p ≤ q) -> p + (q ∸ p) == q
 
+zero-∸ : (n : ℕ) -> (0 ∸ n == 0)
+zero-∸ 0 = idp
+zero-∸ (S n) = idp
+
+∸-anti-≤ : {p q r : ℕ} -> (q ≤ p) -> (r ∸ p) ≤ (r ∸ q)
+∸-anti-≤ {p} {.0} {r} z≤n = ∸-implies-≤ {r ∸ p} {r} {p} idp
+∸-anti-≤ {S p} {S q} {O} (s≤s qp) = z≤n
+∸-anti-≤ {S p} {S q} {S r} (s≤s qp) = ∸-anti-≤ {p} {q} {r} qp
 
 ≰⇒> : {m n : ℕ} -> ¬ (m ≤ n) -> n < m
 ≰⇒> {O} {n} p = ⊥-elim (p z≤n)
@@ -144,10 +151,6 @@ postulate
 ≰⇒> {S m} {S n} p = 
   let rec = ≰⇒> {m} {n} (λ x → p (s≤s x))
   in  s≤s rec
-
-zero-∸ : (n : ℕ) -> (0 ∸ n == 0)
-zero-∸ 0 = idp
-zero-∸ (S n) = idp
 
 ∸-∸-+ : {p q r : ℕ} -> (r ≤ q) -> (q ≤ p + r) -> p ∸ (q ∸ r) == (p + r) ∸ q
 ∸-∸-+ {p} {0} {0} rq qpr = +-comm 0 p

--- a/Pi+/Coxeter/Arithmetic.agda
+++ b/Pi+/Coxeter/Arithmetic.agda
@@ -190,3 +190,46 @@ rrr = ≤-reflexive idp
 squeeze : {n k : ℕ} -> (n < k) -> (k ≤ S n) -> (k == S n)
 squeeze {.0} {.1} (s≤s {n = .0} z≤n) (s≤s z≤n) = idp
 squeeze {.(S _)} {.(S (S _))} (s≤s (s≤s pn)) (s≤s (s≤s pnn)) = ap S (squeeze (s≤s pn) (s≤s pnn))
+
+
+module ≤-Reasoning where
+    infix  1 ≤begin_
+    infixr 2 _≤⟨⟩_ _≤⟨_⟩_ _≡⟨⟩_ _≡⟨_⟩_
+    infix  3 _≤∎
+
+    ≤begin_ : ∀ {x y : ℕ}
+             → x ≤ y
+               -----
+             → x ≤ y
+    ≤begin x≤y  =  x≤y
+
+    _≤⟨⟩_ : ∀ (x : ℕ) {y : ℕ}
+            → x ≤ y
+              -----
+            → x ≤ y
+    x ≤⟨⟩ x≤y  =  x≤y
+
+    _≡⟨⟩_ : ∀ (x : ℕ) {y : ℕ}
+            → x == y
+              -----
+            → x ≤ y
+    x ≡⟨⟩ x≡y  = ≤-reflexive x≡y
+
+    _≤⟨_⟩_ : ∀ (x : ℕ) {y z : ℕ}
+             → x ≤ y
+             → y ≤ z
+               -----
+             → x ≤ z
+    x ≤⟨ x≤y ⟩ y≤z  = ≤-trans x≤y y≤z
+
+    _≡⟨_⟩_ : ∀ (x : ℕ) {y z : ℕ}
+             → x == y
+             → y ≤ z
+               -----
+             → x ≤ z
+    x ≡⟨ x≡y ⟩ y≤z  = ≤-trans (≤-reflexive x≡y) y≤z
+
+    _≤∎ : ∀ (x : ℕ)
+           -----
+          → x ≤ x
+    x ≤∎  = ≤-reflexive idp

--- a/Pi+/Coxeter/Arithmetic.agda
+++ b/Pi+/Coxeter/Arithmetic.agda
@@ -112,30 +112,188 @@ S n ≟ S m with n ≟ m
 ... | no  p = no (λ x → p (≡-down2 x))
 
 
-postulate
-    ∸-implies-≤ : {p q r : ℕ} -> (p == q ∸ r) -> (p ≤ q)
-    ≤-remove-+ : {p q r : ℕ} -> (p + q ≤ r) -> (q ≤ r)
-    introduce-≤-from-+ : {p q r : ℕ} -> (p + q == r) -> (p ≤ r)
-    +-three-assoc : {k i r : ℕ} -> k + (i + r) == (i + k) + r
-    introduce-∸ : {p q r : ℕ} -> (r ≤ q) -> (p + r == q) -> (p == q ∸ r)
-    eliminate-∸ : {p q r : ℕ} -> (r ≤ q) -> (p == q ∸ r) -> (p + r == q)
-    introduce-∸-≤ : {p q r : ℕ} -> (r ≤ q) -> (p + r ≤ q) -> (p ≤ q ∸ r)
-    eliminate-∸-≤ : {p q r : ℕ} -> (r ≤ q) -> (p ≤ q ∸ r) -> (p + r ≤ q)
-    introduce-∸-≤l : {p q r : ℕ} -> (r ≤ p) -> (p ≤ q + r) -> (p ∸ r ≤ q)
-    eliminate-∸-≤l : {p q r : ℕ} -> (r ≤ p) -> (p ∸ r ≤ q) -> (p ≤ q + r)
-    ∸-to-zero : {p q : ℕ} -> (p == q) -> (p ∸ q == 0)
-    minus-plus : {p q : ℕ} -> {q ≤ p} -> p ∸ q + q == p
-    ∸-down2 : {n r : ℕ} -> {r ≤ n} -> ((S n) ∸ (S r)) == n ∸ r
-    ≤-up2-+ : {p q r : ℕ} -> (p ≤ q) -> (r + p ≤ r + q)
-    ≤-up2-r-+ : {p q r : ℕ} -> (p ≤ q) -> (p + r ≤ q + r)
-    ≤-up-r-+ : {p q r : ℕ} -> (p ≤ q) -> (p ≤ q + r)
-    ≤-up-+ : {p q r : ℕ} -> (p ≤ q) -> (p ≤ r + q)
-    ≤-down-+ : {p q r : ℕ} -> (p + r ≤ q) -> (p ≤ q)
-    ≡-down-+ : {p q r : ℕ} -> (r + p == r + q) -> (p == q)
-    ≡-up-+ : {p q p2 q2 : ℕ} -> (p == p2) -> (q == q2) -> (p + q == p2 + q2)
-    ≡-down-r-+ : {p q r : ℕ} -> (p + r == q + r) -> (p == q)
-    ≤-≡ : {n k : ℕ} -> (n ≤ k) -> (k ≤ n) -> (n == k)
-    plus-minus : {p q : ℕ} -> (p ≤ q) -> p + (q ∸ p) == q
+module ≤-Reasoning where
+    infix  1 ≤begin_
+    infixr 2 _≤⟨⟩_ _≤⟨_⟩_ _≡⟨⟩_ _≡⟨_⟩_
+    infix  3 _≤∎
+
+    ≤begin_ : ∀ {x y : ℕ}
+             → x ≤ y
+               -----
+             → x ≤ y
+    ≤begin x≤y  =  x≤y
+
+    _≤⟨⟩_ : ∀ (x : ℕ) {y : ℕ}
+            → x ≤ y
+              -----
+            → x ≤ y
+    x ≤⟨⟩ x≤y  =  x≤y
+
+    _≡⟨⟩_ : ∀ (x : ℕ) {y : ℕ}
+            → x == y
+              -----
+            → x ≤ y
+    x ≡⟨⟩ x≡y  = ≤-reflexive x≡y
+
+    _≤⟨_⟩_ : ∀ (x : ℕ) {y z : ℕ}
+             → x ≤ y
+             → y ≤ z
+               -----
+             → x ≤ z
+    x ≤⟨ x≤y ⟩ y≤z  = ≤-trans x≤y y≤z
+
+    _≡⟨_⟩_ : ∀ (x : ℕ) {y z : ℕ}
+             → x == y
+             → y ≤ z
+               -----
+             → x ≤ z
+    x ≡⟨ x≡y ⟩ y≤z  = ≤-trans (≤-reflexive x≡y) y≤z
+
+    _≤∎ : ∀ (x : ℕ)
+           -----
+          → x ≤ x
+    x ≤∎  = ≤-reflexive idp
+
+open ≤-Reasoning
+
+≤-remove-+ : {p q r : ℕ} -> (p + q ≤ r) -> (q ≤ r)
+≤-remove-+ {p = O} pqr = pqr
+≤-remove-+ {p = S p} {r = S r} (s≤s pqr) = ≤-up (≤-remove-+ pqr)
+
++-three-assoc : {k i r : ℕ} -> k + (i + r) == (i + k) + r
++-three-assoc {k} {i} {r} = ! (+-assoc k i r) ∙ ap (λ e -> e + r) (+-comm k i)
+
+introduce-≤-from-+ : {p q r : ℕ} -> (p + q == r) -> (p ≤ r)
+introduce-≤-from-+ {O} {q} {r} pqr = z≤n
+introduce-≤-from-+ {S p} {q} {S r} pqr = s≤s (introduce-≤-from-+ (≡-down2 pqr))
+
+≤-up2-+ : {p q r : ℕ} -> (p ≤ q) -> (r + p ≤ r + q)
+≤-up2-+ {p} {q} {O} pq = pq
+≤-up2-+ {p} {q} {S r} pq = s≤s (≤-up2-+ pq)
+
++-left : (p r : ℕ) -> S (p + r) == p + S r
++-left p r = +-three-assoc {1} {p} {r} ∙ +-assoc p 1 r
+
+≤-up2-r-+ : {p q r : ℕ} -> (p ≤ q) -> (p + r ≤ q + r)
+≤-up2-r-+ {p} {q} {r} pq =
+  ≤begin
+    _
+  ≡⟨ +-comm p r ⟩
+    r + p
+  ≤⟨ ≤-up2-+ pq ⟩
+    r + q
+  ≡⟨ ! (+-comm q r) ⟩
+    q + r
+  ≤∎
+
+≤-up-+ : {p q r : ℕ} -> (p ≤ q) -> (p ≤ r + q)
+≤-up-+ {p} {q} {O} pq = pq
+≤-up-+ {p} {q} {S r} pq = ≤-up (≤-up-+ pq)
+
+≤-up-r-+ : {p q r : ℕ} -> (p ≤ q) -> (p ≤ q + r)
+≤-up-r-+ {p} {q} {r} pq =
+  ≤begin
+    p
+  ≤⟨ ≤-up-+ pq ⟩
+    r + q
+  ≡⟨ ! (+-comm q r) ⟩
+    q + r
+  ≤∎
+
+
+≤-down-+ : {p q r : ℕ} -> (p + r ≤ q) -> (p ≤ q)
+≤-down-+ {p} {q} {O} pqr = 
+  ≤begin
+    p
+  ≡⟨ +-comm O p ⟩
+    p + O
+  ≤⟨ pqr ⟩
+    q
+  ≤∎
+≤-down-+ {p} {q} {S r} pqr =
+  let lemma =
+        ≤begin
+          S (p + r)
+        ≡⟨ +-left p r  ⟩
+          p + S r
+        ≤⟨ pqr ⟩
+          q
+        ≤∎
+  in ≤-down-+ (≤-down lemma)
+
+≡-down-+ : {p q r : ℕ} -> (r + p == r + q) -> (p == q)
+≡-down-+ {p} {q} {O} pqr = pqr
+≡-down-+ {p} {q} {S r} pqr = ≡-down-+ (≡-down2 pqr)
+
+
+≡-up-+ : {p q p2 q2 : ℕ} -> (p == p2) -> (q == q2) -> (p + q == p2 + q2)
+≡-up-+ {p} {q} {p2} {q2} pp qq = ap (λ e -> e + q) pp ∙ ap (λ e -> p2 + e) qq
+
+
+≡-down-r-+ : {p q r : ℕ} -> (p + r == q + r) -> (p == q)
+≡-down-r-+ {p} {q} {r} pqr = ≡-down-+ (+-comm r p ∙ pqr ∙ (+-comm q r))
+
+
+∸-implies-≤ : {p q r : ℕ} -> (p == q ∸ r) -> (p ≤ q)
+∸-implies-≤ {p} {q} {O} pqr = ≤-reflexive pqr
+∸-implies-≤ {.0} {O} {S r} idp = z≤n
+∸-implies-≤ {p} {S q} {S r} pqr = ≤-up (∸-implies-≤ {p} {q} {r} pqr)
+
+
+introduce-∸ : {p q r : ℕ} -> (r ≤ q) -> (p + r == q) -> (p == q ∸ r)
+introduce-∸ {p} {q} {O} qr pqr = ! (+-comm p O) ∙ pqr
+introduce-∸ {p} {S q} {S r} (s≤s qr) pqr = introduce-∸ {p} {q} {r} qr (≡-down2 ((+-left p r) ∙  pqr))
+
+
+eliminate-∸ : {p q r : ℕ} -> (r ≤ q) -> (p == q ∸ r) -> (p + r == q)
+eliminate-∸ {p} {q} {O} rq pqr = +-comm p O ∙ pqr
+eliminate-∸ {p} {S q} {S r} (s≤s qr) pqr = 
+  let rec = eliminate-∸ {p} {q} {r} qr pqr
+  in  ! (+-left p r) ∙ ap S rec
+
+
+introduce-∸-≤ : {p q r : ℕ} -> (r ≤ q) -> (p + r ≤ q) -> (p ≤ q ∸ r)
+introduce-∸-≤ {p} {q} {O} qr pqr = ≤-trans (≤-reflexive (! (+-comm p O))) pqr
+introduce-∸-≤ {p} {S q} {S r} (s≤s qr) pqr = introduce-∸-≤ {p} {q} {r} qr (≤-down2 (≤-trans (≤-reflexive (+-left p r)) pqr))
+
+
+eliminate-∸-≤ : {p q r : ℕ} -> (r ≤ q) -> (p ≤ q ∸ r) -> (p + r ≤ q)
+eliminate-∸-≤ {p} {q} {O} qr pqr = ≤-trans (≤-reflexive (+-comm p O)) pqr
+eliminate-∸-≤ {p} {S q} {S r} (s≤s qr) pqr = 
+  let rec = eliminate-∸-≤ {p} {q} {r} qr pqr
+  in  ≤-trans (≤-reflexive (! (+-left p r))) (≤-up2 rec)
+
+
+introduce-∸-≤l : {p q r : ℕ} -> (r ≤ p) -> (p ≤ q + r) -> (p ∸ r ≤ q)
+introduce-∸-≤l {p} {q} {O} rp pqr = ≤-trans pqr (≤-reflexive (+-comm q O))
+introduce-∸-≤l {S p} {q} {S r} (s≤s rq) pqr = introduce-∸-≤l {p} {q} {r} rq (≤-down2 (≤-trans pqr (≤-reflexive (! (+-left q r)))))
+
+
+eliminate-∸-≤l : {p q r : ℕ} -> (r ≤ p) -> (p ∸ r ≤ q) -> (p ≤ q + r)
+eliminate-∸-≤l {p} {q} {O} rp pqr = ≤-trans pqr (≤-reflexive (! (+-comm q O)))
+eliminate-∸-≤l {S p} {q} {S r} (s≤s rp) pqr = 
+  let rec = eliminate-∸-≤l {p} {q} {r} rp pqr
+  in  ≤-trans (≤-up2 rec) (≤-reflexive (+-left q r))
+
+
+∸-to-zero : {p q : ℕ} -> (p == q) -> (p ∸ q == 0)
+∸-to-zero {O} {O} pq = idp
+∸-to-zero {S p} {S q} pq = ∸-to-zero (≡-down2 pq)
+
+minus-plus : {p q : ℕ} -> {q ≤ p} -> p ∸ q + q == p
+minus-plus {p} {q} {qp} = eliminate-∸ qp idp
+
+∸-down2 : {n r : ℕ} -> {r ≤ n} -> ((S n) ∸ (S r)) == n ∸ r
+∸-down2 = idp
+
+≤-≡ : {n k : ℕ} -> (n ≤ k) -> (k ≤ n) -> (n == k)
+≤-≡ z≤n z≤n = idp
+≤-≡ (s≤s pnk) (s≤s pkn) = ap S (≤-≡ pnk pkn)
+
+plus-minus : {p q : ℕ} -> (p ≤ q) -> p + (q ∸ p) == q
+plus-minus {.0} {q} z≤n = idp
+plus-minus {.(S _)} {.(S _)} (s≤s pq) = ap S (plus-minus pq)
+
 
 zero-∸ : (n : ℕ) -> (0 ∸ n == 0)
 zero-∸ 0 = idp
@@ -200,44 +358,3 @@ squeeze {.0} {.1} (s≤s {n = .0} z≤n) (s≤s z≤n) = idp
 squeeze {.(S _)} {.(S (S _))} (s≤s (s≤s pn)) (s≤s (s≤s pnn)) = ap S (squeeze (s≤s pn) (s≤s pnn))
 
 
-module ≤-Reasoning where
-    infix  1 ≤begin_
-    infixr 2 _≤⟨⟩_ _≤⟨_⟩_ _≡⟨⟩_ _≡⟨_⟩_
-    infix  3 _≤∎
-
-    ≤begin_ : ∀ {x y : ℕ}
-             → x ≤ y
-               -----
-             → x ≤ y
-    ≤begin x≤y  =  x≤y
-
-    _≤⟨⟩_ : ∀ (x : ℕ) {y : ℕ}
-            → x ≤ y
-              -----
-            → x ≤ y
-    x ≤⟨⟩ x≤y  =  x≤y
-
-    _≡⟨⟩_ : ∀ (x : ℕ) {y : ℕ}
-            → x == y
-              -----
-            → x ≤ y
-    x ≡⟨⟩ x≡y  = ≤-reflexive x≡y
-
-    _≤⟨_⟩_ : ∀ (x : ℕ) {y z : ℕ}
-             → x ≤ y
-             → y ≤ z
-               -----
-             → x ≤ z
-    x ≤⟨ x≤y ⟩ y≤z  = ≤-trans x≤y y≤z
-
-    _≡⟨_⟩_ : ∀ (x : ℕ) {y z : ℕ}
-             → x == y
-             → y ≤ z
-               -----
-             → x ≤ z
-    x ≡⟨ x≡y ⟩ y≤z  = ≤-trans (≤-reflexive x≡y) y≤z
-
-    _≤∎ : ∀ (x : ℕ)
-           -----
-          → x ≤ x
-    x ≤∎  = ≤-reflexive idp

--- a/Pi+/Coxeter/Arithmetic.agda
+++ b/Pi+/Coxeter/Arithmetic.agda
@@ -167,6 +167,10 @@ zero-∸ (S n) = idp
 ∸-up {S (S n)} {0} p = idp
 ∸-up {S (S n)} {S r} (s≤s p) = ∸-up {S n} {r} p
 
+∸-up-r : {n m : ℕ} -> (m ≤ n) -> S (n ∸ m) == S n ∸ m
+∸-up-r {n} {O} q = idp
+∸-up-r {n} {S m} q = ! ((∸-up q))
+
 nowhere : {n k : ℕ} -> (¬ (n < k)) -> (¬ (n == k)) -> (¬ (n == 1 + k)) -> (¬ (1 + k < n)) -> ⊥
 nowhere {0} {0} p1 p2 p3 p4 = p2 idp
 nowhere {0} {S k} p1 p2 p3 p4 = p1 (s≤s z≤n)

--- a/Pi+/Coxeter/Arithmetic.agda
+++ b/Pi+/Coxeter/Arithmetic.agda
@@ -132,6 +132,7 @@ postulate
     ≤-up-+ : {p q r : ℕ} -> (p ≤ q) -> (p ≤ r + q)
     ≤-down-+ : {p q r : ℕ} -> (p + r ≤ q) -> (p ≤ q)
     ≡-down-+ : {p q r : ℕ} -> (r + p == r + q) -> (p == q)
+    ≡-up-+ : {p q p2 q2 : ℕ} -> (p == p2) -> (q == q2) -> (p + q == p2 + q2)
     ≡-down-r-+ : {p q r : ℕ} -> (p + r == q + r) -> (p == q)
     ≤-≡ : {n k : ℕ} -> (n ≤ k) -> (k ≤ n) -> (n == k)
     plus-minus : {p q : ℕ} -> (p ≤ q) -> p + (q ∸ p) == q

--- a/Pi+/Coxeter/CList.agda
+++ b/Pi+/Coxeter/CList.agda
@@ -1,25 +1,19 @@
 {-# OPTIONS --without-K --rewriting #-}
 
-module Pi+.Coxeter.CList where
+module Pi+.Coxeter.Parametrized.CoxeterHIT where
 
 open import lib.Base
 open import lib.Base
 open import lib.NType
 open import lib.NType2
 open import lib.PathOver
-open import lib.types.Nat using (_+_; <-ap-S)
+open import lib.types.Nat using (_+_; <-ap-S; _<_)
 open import lib.types.Sigma
 open import lib.PathGroupoid
 open import lib.Funext
 open import lib.types.Pi
 open import lib.types.Fin
-
-open import Pi+.Misc
-open import Pi+.Coxeter.Arithmetic
-open import Pi+.Coxeter.MCoxeter
-open import Pi+.Coxeter.MCoxeterS
-open import Pi+.Coxeter.Diamond
-open import Pi+.Extra
+open import lib.types.List
 
 ⟨_⟩ : ∀ {n} → Fin n → Fin (S n)
 ⟨_⟩ = Fin-S
@@ -27,50 +21,45 @@ open import Pi+.Extra
 S⟨_⟩ : ∀ {n} → Fin n → Fin (S n)
 S⟨ k , kltn ⟩ = S k , <-ap-S kltn
 
-infixr 35 _::_
 
 postulate
-  CList : ℕ → Type₀
-  nil : ∀ {m} → CList m
-  _::_ : ∀ {m} → Fin (S m) → CList m → CList m
+  cancel : ∀ {m} → {n : Fin (S m)} {w : List (Fin (S m))} → (n :: n :: w) == w
+  swap : ∀ {m} → {n : Fin (S m)} {k : Fin (S m)} → (S (k .fst) < (n .fst)) → {w : List (Fin (S m))} → (n :: k :: w) == (k :: n :: w)
+  braid : ∀ {m} → {n : Fin m} {w : List (Fin (S m))} → (S⟨ n ⟩ :: ⟨ n ⟩ :: S⟨ n ⟩ :: w) == (⟨ n ⟩ :: S⟨ n ⟩ :: ⟨ n ⟩ :: w)
 
-  cancel : ∀ {m} → {n : Fin (S m)} {w : CList m} → (n :: n :: w) == w
-  swap : ∀ {m} → {n : Fin (S m)} {k : Fin (S m)} → (S (k .fst) < (n .fst)) → {w : CList m} → (n :: k :: w) == (k :: n :: w)
-  braid : ∀ {m} → {n : Fin m} {w : CList m} → (S⟨ n ⟩ :: ⟨ n ⟩ :: S⟨ n ⟩ :: w) == (⟨ n ⟩ :: S⟨ n ⟩ :: ⟨ n ⟩ :: w)
+  instance trunc : ∀ {m} → is-set (List (Fin (S m)))
 
-  instance trunc : ∀ {m} → is-set (CList m)
-
-[_] : ∀ {m} → Fin (S m) → CList m
+[_] : ∀ {m} → Fin (S m) → List (Fin (S m))
 [ n ] = n :: nil
 
-module CListElim {i} {m} {P : CList m → Type i}
+module CListElim {i} {m} {P : List (Fin (S m)) → Type i}
   (nil* : P nil)
-  (_::*_ : (n : Fin (S m)) {w : CList m} (w* : P w) → P (n :: w))
-  (cancel* : {n : Fin (S m)} {w : CList m} {w* : P w} → (n ::* (n ::* w*)) == w* [ P ↓ cancel ])
-  (swap* : {n : Fin (S m)} {k : Fin (S m)} → (p : S (k .fst) < (n .fst)) → {w : CList m} {w* : P w} → (n ::* (k ::* w*)) == (k ::* (n ::* w*)) [ P ↓ swap p ])
-  (braid* : {n : Fin m} {w : CList m} {w* : P w} → (S⟨ n ⟩ ::* (⟨ n ⟩ ::* (S⟨ n ⟩ ::* w*))) == (⟨ n ⟩ ::* (S⟨ n ⟩ ::* (⟨ n ⟩ ::* w*))) [ P ↓ braid ])
-  {{trunc* : {w : CList m} → is-set (P w)}}
+  (_::*_ : (n : Fin (S m)) {w : List (Fin (S m))} (w* : P w) → P (n :: w))
+  (cancel* : {n : Fin (S m)} {w : List (Fin (S m))} {w* : P w} → (n ::* (n ::* w*)) == w* [ P ↓ cancel ])
+  (swap* : {n : Fin (S m)} {k : Fin (S m)} → (p : S (k .fst) < (n .fst)) → {w : List (Fin (S m))} {w* : P w} → (n ::* (k ::* w*)) == (k ::* (n ::* w*)) [ P ↓ swap p ])
+  (braid* : {n : Fin m} {w : List (Fin (S m))} {w* : P w} → (S⟨ n ⟩ ::* (⟨ n ⟩ ::* (S⟨ n ⟩ ::* w*))) == (⟨ n ⟩ ::* (S⟨ n ⟩ ::* (⟨ n ⟩ ::* w*))) [ P ↓ braid ])
+  {{trunc* : {w : List (Fin (S m))} → is-set (P w)}}
   where
 
   postulate
-    f : (w : CList m) → P w
+    f : (w : List (Fin (S m))) → P w
     f-nil-β : f nil ↦ nil*
     {-# REWRITE f-nil-β #-}
-    f-::-β : {n : Fin (S m)} {w : CList m} → f (n :: w) ↦ (n ::* (f w))
+    f-::-β : {n : Fin (S m)} {w : List (Fin (S m))} → f (n :: w) ↦ (n ::* (f w))
     {-# REWRITE f-::-β #-}
 
   postulate
-    f-cancel-β : {n : Fin (S m)} {w : CList m} → apd f (cancel {m} {n} {w}) == cancel* {n} {w}
-    f-swap-β : {n : Fin (S m)} {k : Fin (S m)} {w : CList m} → (p : S (k .fst) < (n .fst)) → apd f (swap {m} {n} {k} p {w}) == swap* p {w}
-    f-braid-β : {n : Fin m} {w : CList m} → apd f (braid {m} {n} {w}) == braid* {n} {w}
+    f-cancel-β : {n : Fin (S m)} {w : List (Fin (S m))} → apd f (cancel {m} {n} {w}) == cancel* {n} {w}
+    f-swap-β : {n : Fin (S m)} {k : Fin (S m)} {w : List (Fin (S m))} → (p : S (k .fst) < (n .fst)) → apd f (swap {m} {n} {k} p {w}) == swap* p {w}
+    f-braid-β : {n : Fin m} {w : List (Fin (S m))} → apd f (braid {m} {n} {w}) == braid* {n} {w}
 
-module CListElimProp {i} {m} {P : CList m → Type i}
+module CListElimProp {i} {m} {P : List (Fin (S m)) → Type i}
   (nil* : P nil)
-  (_::*_ : (n : Fin (S m)) {w : CList m} (w* : P w) → P (n :: w))
-  {{trunc* : {w : CList m} → is-prop (P w)}}
+  (_::*_ : (n : Fin (S m)) {w : List (Fin (S m))} (w* : P w) → P (n :: w))
+  {{trunc* : {w : List (Fin (S m))} → is-prop (P w)}}
   where
   private module E = CListElim {P = P} nil* _::*_ prop-has-all-paths-↓ (λ p → prop-has-all-paths-↓) prop-has-all-paths-↓
-  f : (w : CList m) → P w
+  f : (w : List (Fin (S m))) → P w
   f = E.f {{raise-level -1 trunc*}}
 
 module CListRec {i} {m} {P : Type i}
@@ -84,29 +73,29 @@ module CListRec {i} {m} {P : Type i}
 
   private module E = CListElim {P = λ _ → P} nil* (λ n p → n ::* p) (↓-cst-in cancel*) (λ p → ↓-cst-in (swap* p)) (↓-cst-in braid*)
 
-  f : CList m → P
+  f : List (Fin (S m)) → P
   f = E.f
 
-  f-cancel-β : {n : Fin (S m)} {w : CList m} → ap f (cancel {m} {n} {w}) == cancel* {n} {f w}
+  f-cancel-β : {n : Fin (S m)} {w : List (Fin (S m))} → ap f (cancel {m} {n} {w}) == cancel* {n} {f w}
   f-cancel-β = apd=cst-in E.f-cancel-β
 
-  f-swap-β : {n : Fin (S m)} {k : Fin (S m)} → (p : S (k .fst) < (n .fst)) {w : CList m} → ap f (swap {m} {n} {k} p {w}) == swap* p {f w}
+  f-swap-β : {n : Fin (S m)} {k : Fin (S m)} → (p : S (k .fst) < (n .fst)) {w : List (Fin (S m))} → ap f (swap {m} {n} {k} p {w}) == swap* p {f w}
   f-swap-β p = apd=cst-in (E.f-swap-β p)
 
-  f-braid-β : {n : Fin m} {w : CList m} → ap f (braid {m} {n} {w}) == braid* {n} {f w}
+  f-braid-β : {n : Fin m} {w : List (Fin (S m))} → ap f (braid {m} {n} {w}) == braid* {n} {f w}
   f-braid-β = apd=cst-in E.f-braid-β
 
-infixr 50 _++_
+infixr 50 _+++_
 
-_++_ : ∀ {m} → CList m → CList m → CList m
-_++_ {m} = CListRec.f (λ w → w) (λ n f w → n :: f w) (λ= λ _ → cancel) (λ p → λ= λ _ → swap p) (λ= λ _ → braid)
+_+++_ : ∀ {m} → List (Fin (S m)) → List (Fin (S m)) → List (Fin (S m))
+_+++_ {m} = CListRec.f (λ w → w) (λ n f w → n :: f w) (λ= λ _ → cancel) (λ p → λ= λ _ → swap p) (λ= λ _ → braid)
 
 instance
-  clist-paths-prop : ∀ {m} → {w1 w2 : CList m} → is-prop (w1 == w2)
+  clist-paths-prop : ∀ {m} → {w1 w2 : List (Fin (S m))} → is-prop (w1 == w2)
   clist-paths-prop = has-level-apply trunc _ _
 
-++-unit-r : ∀ {m} (l : CList m) → l ++ nil == l
-++-unit-r = CListElimProp.f idp (λ n {w} p → ap (n ::_) p) {{clist-paths-prop}}
++++-unit-r : ∀ {m} (l : List (Fin (S m))) → l +++ nil == l
++++-unit-r = CListElimProp.f idp (λ n {w} p → ap (n ::_) p) {{clist-paths-prop}}
 
-++-assoc : ∀ {m} (l₁ l₂ l₃ : CList m) → (l₁ ++ l₂) ++ l₃ == l₁ ++ (l₂ ++ l₃)
-++-assoc = CListElimProp.f (λ _ _ → idp) (λ n {w} f l₂ l₃ → ap (n ::_) (f l₂ l₃)) {{Π-level λ _ → Π-level λ _ → clist-paths-prop}}
++++-assoc : ∀ {m} (l₁ l₂ l₃ : List (Fin (S m))) → (l₁ +++ l₂) +++ l₃ == l₁ +++ (l₂ +++ l₃)
++++-assoc = CListElimProp.f (λ _ _ → idp) (λ n {w} f l₂ l₃ → ap (n ::_) (f l₂ l₃)) {{Π-level λ _ → Π-level λ _ → clist-paths-prop}}

--- a/Pi+/Coxeter/CList.agda
+++ b/Pi+/Coxeter/CList.agda
@@ -7,19 +7,12 @@ open import lib.Base
 open import lib.NType
 open import lib.NType2
 open import lib.PathOver
-open import lib.types.Nat using (_+_; <-ap-S)
+open import lib.types.Nat
 open import lib.types.Sigma
 open import lib.PathGroupoid
 open import lib.Funext
 open import lib.types.Pi
 open import lib.types.Fin
-
-open import Pi+.Misc
-open import Pi+.Coxeter.Arithmetic
-open import Pi+.Coxeter.MCoxeter
-open import Pi+.Coxeter.MCoxeterS
-open import Pi+.Coxeter.Diamond
-open import Pi+.Extra
 
 ⟨_⟩ : ∀ {n} → Fin n → Fin (S n)
 ⟨_⟩ = Fin-S

--- a/Pi+/Coxeter/CList.agda
+++ b/Pi+/Coxeter/CList.agda
@@ -1,19 +1,25 @@
 {-# OPTIONS --without-K --rewriting #-}
 
-module Pi+.Coxeter.Parametrized.CoxeterHIT where
+module Pi+.Coxeter.CList where
 
 open import lib.Base
 open import lib.Base
 open import lib.NType
 open import lib.NType2
 open import lib.PathOver
-open import lib.types.Nat using (_+_; <-ap-S; _<_)
+open import lib.types.Nat using (_+_; <-ap-S)
 open import lib.types.Sigma
 open import lib.PathGroupoid
 open import lib.Funext
 open import lib.types.Pi
 open import lib.types.Fin
-open import lib.types.List
+
+open import Pi+.Misc
+open import Pi+.Coxeter.Arithmetic
+open import Pi+.Coxeter.MCoxeter
+open import Pi+.Coxeter.MCoxeterS
+open import Pi+.Coxeter.Diamond
+open import Pi+.Extra
 
 ⟨_⟩ : ∀ {n} → Fin n → Fin (S n)
 ⟨_⟩ = Fin-S
@@ -21,45 +27,50 @@ open import lib.types.List
 S⟨_⟩ : ∀ {n} → Fin n → Fin (S n)
 S⟨ k , kltn ⟩ = S k , <-ap-S kltn
 
+infixr 35 _::_
 
 postulate
-  cancel : ∀ {m} → {n : Fin (S m)} {w : List (Fin (S m))} → (n :: n :: w) == w
-  swap : ∀ {m} → {n : Fin (S m)} {k : Fin (S m)} → (S (k .fst) < (n .fst)) → {w : List (Fin (S m))} → (n :: k :: w) == (k :: n :: w)
-  braid : ∀ {m} → {n : Fin m} {w : List (Fin (S m))} → (S⟨ n ⟩ :: ⟨ n ⟩ :: S⟨ n ⟩ :: w) == (⟨ n ⟩ :: S⟨ n ⟩ :: ⟨ n ⟩ :: w)
+  CList : ℕ → Type₀
+  nil : ∀ {m} → CList m
+  _::_ : ∀ {m} → Fin (S m) → CList m → CList m
 
-  instance trunc : ∀ {m} → is-set (List (Fin (S m)))
+  cancel : ∀ {m} → {n : Fin (S m)} {w : CList m} → (n :: n :: w) == w
+  swap : ∀ {m} → {n : Fin (S m)} {k : Fin (S m)} → (S (k .fst) < (n .fst)) → {w : CList m} → (n :: k :: w) == (k :: n :: w)
+  braid : ∀ {m} → {n : Fin m} {w : CList m} → (S⟨ n ⟩ :: ⟨ n ⟩ :: S⟨ n ⟩ :: w) == (⟨ n ⟩ :: S⟨ n ⟩ :: ⟨ n ⟩ :: w)
 
-[_] : ∀ {m} → Fin (S m) → List (Fin (S m))
+  instance trunc : ∀ {m} → is-set (CList m)
+
+[_] : ∀ {m} → Fin (S m) → CList m
 [ n ] = n :: nil
 
-module CListElim {i} {m} {P : List (Fin (S m)) → Type i}
+module CListElim {i} {m} {P : CList m → Type i}
   (nil* : P nil)
-  (_::*_ : (n : Fin (S m)) {w : List (Fin (S m))} (w* : P w) → P (n :: w))
-  (cancel* : {n : Fin (S m)} {w : List (Fin (S m))} {w* : P w} → (n ::* (n ::* w*)) == w* [ P ↓ cancel ])
-  (swap* : {n : Fin (S m)} {k : Fin (S m)} → (p : S (k .fst) < (n .fst)) → {w : List (Fin (S m))} {w* : P w} → (n ::* (k ::* w*)) == (k ::* (n ::* w*)) [ P ↓ swap p ])
-  (braid* : {n : Fin m} {w : List (Fin (S m))} {w* : P w} → (S⟨ n ⟩ ::* (⟨ n ⟩ ::* (S⟨ n ⟩ ::* w*))) == (⟨ n ⟩ ::* (S⟨ n ⟩ ::* (⟨ n ⟩ ::* w*))) [ P ↓ braid ])
-  {{trunc* : {w : List (Fin (S m))} → is-set (P w)}}
+  (_::*_ : (n : Fin (S m)) {w : CList m} (w* : P w) → P (n :: w))
+  (cancel* : {n : Fin (S m)} {w : CList m} {w* : P w} → (n ::* (n ::* w*)) == w* [ P ↓ cancel ])
+  (swap* : {n : Fin (S m)} {k : Fin (S m)} → (p : S (k .fst) < (n .fst)) → {w : CList m} {w* : P w} → (n ::* (k ::* w*)) == (k ::* (n ::* w*)) [ P ↓ swap p ])
+  (braid* : {n : Fin m} {w : CList m} {w* : P w} → (S⟨ n ⟩ ::* (⟨ n ⟩ ::* (S⟨ n ⟩ ::* w*))) == (⟨ n ⟩ ::* (S⟨ n ⟩ ::* (⟨ n ⟩ ::* w*))) [ P ↓ braid ])
+  {{trunc* : {w : CList m} → is-set (P w)}}
   where
 
   postulate
-    f : (w : List (Fin (S m))) → P w
+    f : (w : CList m) → P w
     f-nil-β : f nil ↦ nil*
     {-# REWRITE f-nil-β #-}
-    f-::-β : {n : Fin (S m)} {w : List (Fin (S m))} → f (n :: w) ↦ (n ::* (f w))
+    f-::-β : {n : Fin (S m)} {w : CList m} → f (n :: w) ↦ (n ::* (f w))
     {-# REWRITE f-::-β #-}
 
   postulate
-    f-cancel-β : {n : Fin (S m)} {w : List (Fin (S m))} → apd f (cancel {m} {n} {w}) == cancel* {n} {w}
-    f-swap-β : {n : Fin (S m)} {k : Fin (S m)} {w : List (Fin (S m))} → (p : S (k .fst) < (n .fst)) → apd f (swap {m} {n} {k} p {w}) == swap* p {w}
-    f-braid-β : {n : Fin m} {w : List (Fin (S m))} → apd f (braid {m} {n} {w}) == braid* {n} {w}
+    f-cancel-β : {n : Fin (S m)} {w : CList m} → apd f (cancel {m} {n} {w}) == cancel* {n} {w}
+    f-swap-β : {n : Fin (S m)} {k : Fin (S m)} {w : CList m} → (p : S (k .fst) < (n .fst)) → apd f (swap {m} {n} {k} p {w}) == swap* p {w}
+    f-braid-β : {n : Fin m} {w : CList m} → apd f (braid {m} {n} {w}) == braid* {n} {w}
 
-module CListElimProp {i} {m} {P : List (Fin (S m)) → Type i}
+module CListElimProp {i} {m} {P : CList m → Type i}
   (nil* : P nil)
-  (_::*_ : (n : Fin (S m)) {w : List (Fin (S m))} (w* : P w) → P (n :: w))
-  {{trunc* : {w : List (Fin (S m))} → is-prop (P w)}}
+  (_::*_ : (n : Fin (S m)) {w : CList m} (w* : P w) → P (n :: w))
+  {{trunc* : {w : CList m} → is-prop (P w)}}
   where
   private module E = CListElim {P = P} nil* _::*_ prop-has-all-paths-↓ (λ p → prop-has-all-paths-↓) prop-has-all-paths-↓
-  f : (w : List (Fin (S m))) → P w
+  f : (w : CList m) → P w
   f = E.f {{raise-level -1 trunc*}}
 
 module CListRec {i} {m} {P : Type i}
@@ -73,29 +84,29 @@ module CListRec {i} {m} {P : Type i}
 
   private module E = CListElim {P = λ _ → P} nil* (λ n p → n ::* p) (↓-cst-in cancel*) (λ p → ↓-cst-in (swap* p)) (↓-cst-in braid*)
 
-  f : List (Fin (S m)) → P
+  f : CList m → P
   f = E.f
 
-  f-cancel-β : {n : Fin (S m)} {w : List (Fin (S m))} → ap f (cancel {m} {n} {w}) == cancel* {n} {f w}
+  f-cancel-β : {n : Fin (S m)} {w : CList m} → ap f (cancel {m} {n} {w}) == cancel* {n} {f w}
   f-cancel-β = apd=cst-in E.f-cancel-β
 
-  f-swap-β : {n : Fin (S m)} {k : Fin (S m)} → (p : S (k .fst) < (n .fst)) {w : List (Fin (S m))} → ap f (swap {m} {n} {k} p {w}) == swap* p {f w}
+  f-swap-β : {n : Fin (S m)} {k : Fin (S m)} → (p : S (k .fst) < (n .fst)) {w : CList m} → ap f (swap {m} {n} {k} p {w}) == swap* p {f w}
   f-swap-β p = apd=cst-in (E.f-swap-β p)
 
-  f-braid-β : {n : Fin m} {w : List (Fin (S m))} → ap f (braid {m} {n} {w}) == braid* {n} {f w}
+  f-braid-β : {n : Fin m} {w : CList m} → ap f (braid {m} {n} {w}) == braid* {n} {f w}
   f-braid-β = apd=cst-in E.f-braid-β
 
-infixr 50 _+++_
+infixr 50 _++_
 
-_+++_ : ∀ {m} → List (Fin (S m)) → List (Fin (S m)) → List (Fin (S m))
-_+++_ {m} = CListRec.f (λ w → w) (λ n f w → n :: f w) (λ= λ _ → cancel) (λ p → λ= λ _ → swap p) (λ= λ _ → braid)
+_++_ : ∀ {m} → CList m → CList m → CList m
+_++_ {m} = CListRec.f (λ w → w) (λ n f w → n :: f w) (λ= λ _ → cancel) (λ p → λ= λ _ → swap p) (λ= λ _ → braid)
 
 instance
-  clist-paths-prop : ∀ {m} → {w1 w2 : List (Fin (S m))} → is-prop (w1 == w2)
+  clist-paths-prop : ∀ {m} → {w1 w2 : CList m} → is-prop (w1 == w2)
   clist-paths-prop = has-level-apply trunc _ _
 
-+++-unit-r : ∀ {m} (l : List (Fin (S m))) → l +++ nil == l
-+++-unit-r = CListElimProp.f idp (λ n {w} p → ap (n ::_) p) {{clist-paths-prop}}
+++-unit-r : ∀ {m} (l : CList m) → l ++ nil == l
+++-unit-r = CListElimProp.f idp (λ n {w} p → ap (n ::_) p) {{clist-paths-prop}}
 
-+++-assoc : ∀ {m} (l₁ l₂ l₃ : List (Fin (S m))) → (l₁ +++ l₂) +++ l₃ == l₁ +++ (l₂ +++ l₃)
-+++-assoc = CListElimProp.f (λ _ _ → idp) (λ n {w} f l₂ l₃ → ap (n ::_) (f l₂ l₃)) {{Π-level λ _ → Π-level λ _ → clist-paths-prop}}
+++-assoc : ∀ {m} (l₁ l₂ l₃ : CList m) → (l₁ ++ l₂) ++ l₃ == l₁ ++ (l₂ ++ l₃)
+++-assoc = CListElimProp.f (λ _ _ → idp) (λ n {w} f l₂ l₃ → ap (n ::_) (f l₂ l₃)) {{Π-level λ _ → Π-level λ _ → clist-paths-prop}}

--- a/Pi+/Coxeter/CanonicalForm.agda
+++ b/Pi+/Coxeter/CanonicalForm.agda
@@ -51,7 +51,6 @@ unproperize {S nf} (CanS {n} {.(S nf)} x cl {r} x₁) =
       rec-l , rec-p = canonical-lift nf (≤-down2 x) nfr
   in  CanS rec-l x₁ , ap (λ e -> e ++ (r + nf ∸ r :: nf ∸ r ↓ r)) (clfr ∙ ! rec-p)
 
-
 canonical-proper-append : {n : ℕ} -> (cl : LehmerProper n) -> (x : ℕ) -> (n ≤ x) -> Σ _ (λ clx -> immersionProper {S x} clx == immersionProper {n} cl ++ [ x ])
 canonical-proper-append cl x px with unproperize cl
 ... | upl , upl-p with canonical-append upl x px
@@ -130,14 +129,6 @@ abs-list : {l : List} -> {n : ℕ} -> {r : List} -> (nil == (l ++ (n :: r))) -> 
 abs-list {nil} {n} {r} ()
 abs-list {x :: l} {n} {r} ()
 
-cut-last : {l1 l2 : List} -> {x1 x2 : ℕ} -> (l1 ++ [ x1 ] == l2 ++ [ x2 ]) -> (l1 == l2)
-cut-last {nil} {nil} p = idp
-cut-last {nil} {x :: nil} ()
-cut-last {nil} {x :: x₁ :: l2} ()
-cut-last {x :: nil} {nil} ()
-cut-last {x :: x₁ :: l1} {nil} ()
-cut-last {x :: l1} {x₁ :: l2} p = head+tail (cut-tail p) (cut-last (cut-head p))
-
 cut-last-Lehmer : {n : ℕ} -> {l : List} -> (x : ℕ) -> (cl : LehmerProper n) -> (immersionProper cl == l ++ [ x ]) -> Σ _ (λ nf -> Σ _ (λ clf -> immersionProper {nf} clf == l))
 cut-last-Lehmer {0} {l} x CanZ pp = ⊥-elim (abs-list pp)
 cut-last-Lehmer {S n} {l} x (CanS pn cl {0} pr) pp = _ , (cl , cut-last pp)
@@ -178,11 +169,13 @@ is-canonical? (x :: m) with is-canonical? m
 ... | no qq = no λ {
   (_ , CanZ , pp) → abs-list pp ;
   (_ , CanS (s≤s x) CanZ {0} (s≤s z≤n) , ppp) →
-    let m-empty = cut-last {nil} ppp
+    let m-empty = cut-last {_} {_} {nil} ppp
     in  abs-list (≡-trans m-empty (≡-sym pp)) ;
-  (_ , CanS {0} {S (S n₁)} (s≤s x₁) CanZ {S m₁} (s≤s (s≤s x₂)), snd₁) -> {!   !} ;
-  (_ , CanS (s≤s x₁) (CanS x₂ fst₁ x₃) {O} x₄ , snd₁) -> {!   !} ;
-  (_ , CanS (s≤s x₁) (CanS x₂ fst₁ x₃) {S r} x₄ , snd₁) -> {!   !}
+  (S _ , CanS (s≤s x₁) (CanS x₂ fst₁ x₃) (s≤s z≤n) , snd₁) -> ? ;
+  (S (S _) , CanS (s≤s x₁) fst₁ (s≤s (s≤s x₂)) , snd₁) -> ?
+  -- (_ , CanS {0} {S (S n₁)} (s≤s x₁) CanZ {S m₁} (s≤s (s≤s x₂)), snd₁) -> {!   !} ;
+  -- (_ , CanS (s≤s x₁) (CanS x₂ fst₁ x₃) {O} x₄ , snd₁) -> {!   !} ;
+  -- (_ , CanS (s≤s x₁) (CanS x₂ fst₁ x₃) {S r} x₄ , snd₁) -> {!   !}
   }
 
 canonical-proper-NF : {n : ℕ} -> (cl : LehmerProper n) -> (Σ _ (λ m -> immersionProper {n} cl ≅ m)) -> ⊥

--- a/Pi+/Coxeter/CanonicalForm.agda
+++ b/Pi+/Coxeter/CanonicalForm.agda
@@ -100,7 +100,16 @@ lemma n r x pnr m f with n <? x
 
 canonical-proper-append-smaller : {n nf r : ℕ} -> {pn : S n ≤ S nf} -> {pr : S r ≤ S nf} -> {cl : LehmerProper n} -> (x : ℕ) -> (clf : LehmerProper (S nf)) -> (defclf : clf == CanS pn cl pr)
                                   -> (defx : S x == (nf ∸ r)) -> Σ (S r < S nf) (λ prr -> immersionProper {S nf} (CanS pn cl prr) == (immersionProper {S nf} clf) ++ [ x ])
-canonical-proper-append-smaller {n} {nf} {r} {pn} {pr} {cl} x clf defclf defx = {!  !}
+canonical-proper-append-smaller {n} {nf} {r} {pn} {pr} {cl} x clf defclf defx = 
+  let x+Sr=nf = ≡-down2 (eliminate-∸ pr defx)
+      r<nf = introduce-≤-from-+ {S r} {x} {nf} (ap S (+-comm r x) ∙ (! (+-three-assoc {x} {1} {r})) ∙ x+Sr=nf)
+      x=nf-Sr = ! (introduce-∸ r<nf x+Sr=nf)
+      lemma = ++-↓ (nf ∸ r) r
+  in  ≤-up2 r<nf , 
+    ap (λ e -> immersionProper cl ++ e) (head+tail ((plus-minus {S r} {nf} r<nf) ∙ (! (plus-minus {r} {nf} (≤-down r<nf)))) (! (++-↓-S (nf ∸ r) r x defx ∙ 
+      transport {!   !} x=nf-Sr {!   !}))) ∙ 
+    ! (++-assoc (immersionProper cl) (r + nf ∸ r :: nf ∸ r ↓ r) [ x ]) ∙ 
+    ap (λ e -> immersionProper e ++ [ x ]) (! defclf)
 
 canonical-final≅ : (m : List) -> (f : (mf : List) -> (rev m ≅+ mf) -> ⊥) -> Σ _ (λ n -> Σ _ (λ cl -> immersionProper {n} cl == rev m))
 canonical-final≅ nil f = O , CanZ , idp

--- a/Pi+/Coxeter/CanonicalForm.agda
+++ b/Pi+/Coxeter/CanonicalForm.agda
@@ -107,7 +107,7 @@ canonical-proper-append-smaller {n} {nf} {r} {pn} {pr} {cl} x clf defclf defx =
       lemma = ++-↓ (nf ∸ r) r
   in  ≤-up2 r<nf , 
     ap (λ e -> immersionProper cl ++ e) (head+tail ((plus-minus {S r} {nf} r<nf) ∙ (! (plus-minus {r} {nf} (≤-down r<nf)))) (! (++-↓-S (nf ∸ r) r x defx ∙ 
-      transport {!   !} x=nf-Sr {!   !}))) ∙ 
+      transport (λ e -> r + e :: e ↓ r == r + nf ∸ S r :: nf ∸ S r ↓ r ) x=nf-Sr idp))) ∙ 
     ! (++-assoc (immersionProper cl) (r + nf ∸ r :: nf ∸ r ↓ r) [ x ]) ∙ 
     ap (λ e -> immersionProper e ++ [ x ]) (! defclf)
 

--- a/Pi+/Coxeter/CanonicalForm.agda
+++ b/Pi+/Coxeter/CanonicalForm.agda
@@ -40,23 +40,24 @@ properize CanZ = O , CanZ , idp , z≤n
 properize (CanS cl {O} x) = 
   let nrec , clfrec , clfrecp , nfr = properize cl
   in  nrec , clfrec , (++-unit ∙ clfrecp) , ≤-up nfr
-properize (CanS {n} cl {S r} x) with properize cl 
-... | .0 , CanZ , clfrecp , nfn = (S n) , ((CanS (s≤s z≤n) CanZ x) , ((ap (λ e -> e ++ ((r + n ∸ r) :: (n ∸ r) ↓ r)) clfrecp)) , ≤-reflexive idp )
-... | S nrec , CanS {nr} {nfr} pnf clfrec {rr} pnr , clfrecp , nfn = S n , (CanS (s≤s nfn) (CanS pnf clfrec pnr) x) ,  (ap (λ e -> e ++ ((r + n ∸ r) :: (n ∸ r) ↓ r)) clfrecp) , ≤-reflexive idp
+properize (CanS {n} cl {S r} x) =
+  let (k , clrec , clfrecp , nfn) = properize cl
+  in  S n , CanS (s≤s nfn) clrec x , (ap (λ e -> e ++ ((r + n ∸ r) :: (n ∸ r) ↓ r)) clfrecp) , ≤-reflexive idp
 
 unproperize : {n : ℕ} -> (cl : LehmerProper n) -> Σ _ (λ clf -> immersionProper {n} cl == immersion {n} clf)
 unproperize CanZ = CanZ , idp
-unproperize {S nf} (CanS {n} {.(S nf)} x cl {r} x₁) with unproperize cl
-... | nfr , clfr with canonical-lift nf (≤-down2 x) nfr
-...    | rec-l , rec-p = CanS rec-l x₁ , ap (λ e -> e ++ (r + nf ∸ r :: nf ∸ r ↓ r)) (clfr ∙ ! rec-p)
+unproperize {S nf} (CanS {n} {.(S nf)} x cl {r} x₁) =
+  let nfr , clfr = unproperize cl 
+      rec-l , rec-p = canonical-lift nf (≤-down2 x) nfr
+  in  CanS rec-l x₁ , ap (λ e -> e ++ (r + nf ∸ r :: nf ∸ r ↓ r)) (clfr ∙ ! rec-p)
 
 
 canonical-proper-append : {n : ℕ} -> (cl : LehmerProper n) -> (x : ℕ) -> (n ≤ x) -> Σ _ (λ clx -> immersionProper {S x} clx == immersionProper {n} cl ++ [ x ])
 canonical-proper-append cl x px with unproperize cl
 ... | upl , upl-p with canonical-append upl x px
-...    | (CanS clx {r} SxSx) , clx-p = 
-          let nf , clf , clfp , nfp = properize (CanS clx SxSx)
-          in  transport LehmerProper (≤-≡ nfp {! SxSx  !}) clf , (((! (immersionProper-transport {!   !} clf)) ∙ ! clfp) ∙ clx-p) ∙ ap (λ e -> e ++ [ x ]) (! upl-p)
+...    | clx , clx-p = 
+          let nf , clf , clfp , nfp = properize (CanS {x} clx {1} (≤-up2 z≤n))
+          in  transport LehmerProper (≤-≡ nfp rrr) clf , ((! ((immersionProper-transport ((≤-≡ (s≤s (≤-reflexive idp)) (s≤s (≤-reflexive idp)))) clf)) ∙ ! clfp) ∙ clx-p) ∙ ap (λ e -> e ++ [ x ]) (! upl-p)
 
 
 always-reduces : (n k x : ℕ) -> (x ≤ k + n) -> (Σ _ (λ mf -> (n ↓ (1 + k) ++ [ x ]) ≅+ mf)) ⊎ (S x == n)

--- a/Pi+/Coxeter/CanonicalForm.agda
+++ b/Pi+/Coxeter/CanonicalForm.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --allow-unsolved-metas #-}
+{-# OPTIONS --without-K --rewriting #-}
 
 module Pi+.Coxeter.CanonicalForm where
 
@@ -17,6 +17,7 @@ open import Pi+.Coxeter.ReductionRel+
 open import Pi+.Coxeter.ExchangeLemmas
 open import Pi+.Coxeter.ExchangeLemmas+
 open import Pi+.Coxeter.Lehmer
+open import Pi+.Coxeter.ImpossibleLists
 
 open ≅*-Reasoning
 
@@ -55,76 +56,120 @@ unproperize {S nf} (CanS {n} {.(S nf)} x cl {r} x₁) =
       rec-l , rec-p = canonical-lift nf (≤-down2 x) nfr
   in  CanS rec-l x₁ , ap (λ e -> e ++ (r + nf ∸ r :: nf ∸ r ↓ r)) (clfr ∙ ! rec-p)
 
-properize-fn : {n : ℕ} -> (cl : Lehmer n) -> Σ _ (λ nf → LehmerProper nf)
-properize-fn cl = let (nf , clf , _) = properize cl in (nf , clf)
-
-unproperize-fn : {n : ℕ} -> (cl : LehmerProper n) -> Lehmer n
-unproperize-fn = fst ∘ unproperize
-
-properize∘unproperize-fn-n : {n : ℕ} -> (cl : LehmerProper n) -> n == fst (properize-fn (unproperize-fn cl))
-properize∘unproperize-fn-n {O} CanZ = idp
-properize∘unproperize-fn-n {S n} (CanS x cl x₁) = idp
-
-properize∘unproperize-fn : {n : ℕ} -> (cl : LehmerProper n) → PathOver LehmerProper (properize∘unproperize-fn-n cl) cl (snd (properize-fn (unproperize-fn cl))) 
-properize∘unproperize-fn {O} CanZ = idp
-properize∘unproperize-fn {S n} (CanS x cl x₁) = 
-  let rec = properize∘unproperize-fn cl
-      t = ap↓ (λ e -> CanS x e x₁) rec 
-  in  {!   !}
-
 immersionProper->> : {n : ℕ} -> (cl : LehmerProper n) -> n >> immersionProper cl
 immersionProper->> {n} cl = 
   let clp , clp-r = unproperize cl
   in  transport (λ e -> n >> e) (! clp-r) (immersion->> clp)
 
-≡immersionProper : {nf : ℕ} -> (cl1 cl2 : LehmerProper nf) -> (immersionProper {nf} cl1 == immersionProper {nf} cl2) -> cl1 == cl2
-≡immersionProper {nf} cl1 cl2 p = 
-  let clu1 , clu1-p = unproperize cl1
-      clu2 , clu2-p = unproperize cl2
-      q : unproperize-fn cl1 == unproperize-fn cl2
-      q = ≡immersion clu1 clu2 (! clu1-p ∙ p ∙ clu2-p) 
 
-      -- LehmerProper (fst (properize (fst (unproperize cl1))))
-      qap : PathOver (λ e → LehmerProper (fst (properize e))) q (snd (properize-fn {nf} (unproperize-fn cl1))) (snd (properize-fn {nf} (unproperize-fn cl2)))
-      qap = apd (λ e -> snd (properize-fn {nf} e)) q 
+-- properize-fn : {n : ℕ} -> (cl : Lehmer n) -> Σ _ (λ nf → LehmerProper nf)
+-- properize-fn cl = let (nf , clf , _) = properize cl in (nf , clf)
 
-      question : fst (properize-fn {nf} (unproperize-fn cl1)) == fst (properize-fn {nf} (unproperize-fn cl2))
-      question = ap (λ e -> fst (properize e)) q
+-- unproperize-fn : {n : ℕ} -> (cl : LehmerProper n) -> Lehmer n
+-- unproperize-fn = fst ∘ unproperize
+
+-- properize∘unproperize-fn-n : {n : ℕ} -> (cl : LehmerProper n) -> n == fst (properize-fn (unproperize-fn cl))
+-- properize∘unproperize-fn-n {O} CanZ = idp
+-- properize∘unproperize-fn-n {S n} (CanS x cl x₁) = idp
+
+-- properize∘unproperize-fn : {n : ℕ} -> (cl : LehmerProper n) → PathOver LehmerProper (properize∘unproperize-fn-n cl) cl (snd (properize-fn (unproperize-fn cl))) 
+-- properize∘unproperize-fn {O} CanZ = idp
+-- properize∘unproperize-fn {S n} (CanS x cl x₁) = 
+--   let rec = properize∘unproperize-fn cl
+--       t = ap↓ (λ e -> CanS x e x₁) rec 
+--   in  {!   !}
+
+-- ≡immersionProper : {nf : ℕ} -> (cl1 cl2 : LehmerProper nf) -> (immersionProper {nf} cl1 == immersionProper {nf} cl2) -> cl1 == cl2
+-- ≡immersionProper {nf} cl1 cl2 p = 
+--   let clu1 , clu1-p = unproperize cl1
+--       clu2 , clu2-p = unproperize cl2
+--       q : unproperize-fn cl1 == unproperize-fn cl2
+--       q = ≡immersion clu1 clu2 (! clu1-p ∙ p ∙ clu2-p) 
+
+--       -- LehmerProper (fst (properize (fst (unproperize cl1))))
+--       qap : PathOver (λ e → LehmerProper (fst (properize e))) q (snd (properize-fn {nf} (unproperize-fn cl1))) (snd (properize-fn {nf} (unproperize-fn cl2)))
+--       qap = apd (λ e -> snd (properize-fn {nf} e)) q 
+
+--       question : fst (properize-fn {nf} (unproperize-fn cl1)) == fst (properize-fn {nf} (unproperize-fn cl2))
+--       question = ap (λ e -> fst (properize e)) q
       
-      qap' : PathOver LehmerProper question (snd (properize-fn {nf} (unproperize-fn cl1))) ((snd (properize-fn {nf} (unproperize-fn cl2))))
-      qap' = ↓-ap-in LehmerProper (λ x →  fst (properize x)) qap
+--       qap' : PathOver LehmerProper question (snd (properize-fn {nf} (unproperize-fn cl1))) ((snd (properize-fn {nf} (unproperize-fn cl2))))
+--       qap' = ↓-ap-in LehmerProper (λ x →  fst (properize x)) qap
 
-      -- ↓-ap-in : u == v [ C ∘ f ↓ p ] → u == v [ C ↓ ap f p ]  -- book, 2.7.somethin
-      -- transport P p u = coe (ap P p) u
-      -- transport P (ap f q) u = coe (ap P (ap f q)) u = coe (ap (P ∘ f) q) u
+--       -- ↓-ap-in : u == v [ C ∘ f ↓ p ] → u == v [ C ↓ ap f p ]  -- book, 2.7.somethin
+--       -- transport P p u = coe (ap P p) u
+--       -- transport P (ap f q) u = coe (ap P (ap f q)) u = coe (ap (P ∘ f) q) u
 
-      cl1-r' : PathOver LehmerProper (properize∘unproperize-fn-n cl1) cl1 (snd (properize-fn {nf} (unproperize-fn cl1)))
-      cl1-r' = properize∘unproperize-fn cl1
-      cl2-r' : PathOver LehmerProper (properize∘unproperize-fn-n cl2) cl2 (snd (properize-fn {nf} (unproperize-fn cl2)))
-      cl2-r' = properize∘unproperize-fn cl2  
+--       cl1-r' : PathOver LehmerProper (properize∘unproperize-fn-n cl1) cl1 (snd (properize-fn {nf} (unproperize-fn cl1)))
+--       cl1-r' = properize∘unproperize-fn cl1
+--       cl2-r' : PathOver LehmerProper (properize∘unproperize-fn-n cl2) cl2 (snd (properize-fn {nf} (unproperize-fn cl2)))
+--       cl2-r' = properize∘unproperize-fn cl2  
 
-      ttp : nf == nf
-      ttp = (properize∘unproperize-fn-n cl1 ∙ question ∙ ! (properize∘unproperize-fn-n cl2))
-      ttp-idp : ttp == idp
-      ttp-idp = prop-has-all-paths {{has-level-apply ℕ-level nf nf}} ttp idp
+--       ttp : nf == nf
+--       ttp = (properize∘unproperize-fn-n cl1 ∙ question ∙ ! (properize∘unproperize-fn-n cl2))
+--       ttp-idp : ttp == idp
+--       ttp-idp = prop-has-all-paths {{has-level-apply ℕ-level nf nf}} ttp idp
 
-      tt : PathOver LehmerProper ttp cl1 cl2
-      tt = cl1-r' ∙ᵈ qap' ∙ᵈ (!ᵈ cl2-r')
+--       tt : PathOver LehmerProper ttp cl1 cl2
+--       tt = cl1-r' ∙ᵈ qap' ∙ᵈ (!ᵈ cl2-r')
 
-      t : cl1 == cl2
-      t = transport (λ z → PathOver LehmerProper z cl1 cl2) ttp-idp tt
-  in  t
+--       t : cl1 == cl2
+--       t = transport (λ z → PathOver LehmerProper z cl1 cl2) ttp-idp tt
+--   in  t
 
-postulate
-  ≡immersionProper-n : {nf1 nf2 : ℕ} -> (cl1 : LehmerProper nf1) -> (cl2 : LehmerProper nf2) -> (immersionProper {nf1} cl1 == immersionProper {nf2} cl2) -> nf1 == nf2
-  ≡immersionProper-n : {nf1 nf2 : ℕ} -> (cl1 : LehmerProper nf1) -> (cl2 : LehmerProper nf2) -> (immersionProper {nf1} cl1 == immersionProper {nf2} cl2) -> nf1 == nf2
+extractProper-r : {k : ℕ} -> LehmerProper (S k) -> ℕ
+extractProper-r (CanS _ _ {r} _) = r
 
--- ≡immersionProper : {nf1 nf2 : ℕ} -> (cl1 : LehmerProper nf1) -> (cl2 : LehmerProper nf2) -> (immersionProper {nf1} cl1 == immersionProper {nf2} cl2) -> nf1 == nf2
--- ≡immersionProper {O} {O} cl1 cl2 p = idp
--- ≡immersionProper {O} {S nf2} CanZ (CanS x cl2 x₁) p = ⊥-elim (++-abs-lr (! p))
--- ≡immersionProper {S nf1} {O} (CanS x cl1 x₁) CanZ p = ⊥-elim (++-abs-lr p)
--- ≡immersionProper {S nf1} {S nf2} (CanS x cl1 x₁) (CanS x₂ cl2 x₃) p = 
---   let rec = ≡immersionProper cl1 cl2 {!   !}
+extract-r : {k : ℕ} -> Lehmer (S k) -> ℕ
+extract-r (CanS _ {r} _) = r
+
+≡immersion-r : {nf : ℕ} -> (cl1 : Lehmer (S nf)) -> (cl2 : Lehmer (S nf)) -> (immersion {S nf} cl1 == immersion {S nf} cl2) -> (extract-r cl1) == (extract-r cl2)
+≡immersion-r cl1 cl2 p with (≡immersion cl1 cl2 p)
+... | idp = idp
+
+≡-↓-Proper : (n1 n2 k1 k2 : ℕ) -> ((n1 ↓ S k1) == (n2 ↓ S k2)) -> (n1 == n2) × (k1 == k2)
+≡-↓-Proper n1 n2 O O p = (cut-tail p) , idp
+≡-↓-Proper n1 n2 (S k1) (S k2) p = 
+  let rec-n , rec-k = ≡-↓-Proper n1 n2 k1 k2 (cut-head p) 
+  in  rec-n , ap S rec-k
+
+>>-up : {n1 n2 : ℕ} -> (n1 ≤ n2) -> {l : List} -> (n1 >> l) -> (n2 >> l)
+>>-up pn nil = nil
+>>-up pn (k :⟨ x ⟩: xs) = k :⟨ (≤-trans x pn) ⟩: (>>-up pn xs)
+
+≡-++↓-Proper : (m1 m2 : List) -> (n1 n2 k1 k2 : ℕ) -> (x1 : S n1 >> m1) -> (x2 : S n2 >> m2) -> (k1 ≤ n1) -> (k2 ≤ n2) -> (m1 ++ ((n1 ∸ k1) ↓ S k1) == m2 ++ ((n2 ∸ k2) ↓ S k2)) 
+  -> (n1 == n2) × (k1 == k2) × (m1 == m2)
+≡-++↓-Proper nil nil n1 n2 k1 k2 x1 x2 pkn1 pkn2 p = 
+  let pkn , pk = ≡-↓-Proper (n1 ∸ k1) (n2 ∸ k2) k1 k2 p
+      pn = (! (minus-plus {_} {_} {pkn1})) ∙ (≡-up-+ pkn pk) ∙ (minus-plus {_} {_} {pkn2})
+  in  pn , (pk , idp)
+≡-++↓-Proper nil (x :: m2) n1 n2 k1 k2 x1 x2 pkn1 pkn2 p =
+  ⊥-elim (repeat-spaced-long-lemma (n1 ∸ k1) (S k1) x (k2 + n2 ∸ k2) (≤-trans (≤-down2 (extract-proof x2)) (≤-reflexive (! (plus-minus pkn2)))) nil m2 (n2 ∸ k2 ↓ k2) p)
+≡-++↓-Proper (x :: m1) nil n1 n2 k1 k2 x1 x2 pkn1 pkn2 p = 
+  let pn , pk , pm = ≡-++↓-Proper nil (x :: m1) n2 n1 k2 k1 x2 x1 pkn2 pkn1 (! p)
+  in  (! pn) , ((! pk) , (! pm))
+≡-++↓-Proper (x :: m1) (x₁ :: m2) n1 n2 k1 k2 (_ :⟨ _ ⟩: x1) (_ :⟨ _ ⟩: x2) pkn1 pkn2 p =
+  let pn , pk , pm = ≡-++↓-Proper m1 m2 n1 n2 k1 k2 x1 x2 pkn1 pkn2 (cut-head p)
+  in  pn , pk , head+tail (cut-tail p) pm
+
+
+≡immersionProper-n : {nf1 nf2 : ℕ} -> (cl1 : LehmerProper nf1) -> (cl2 : LehmerProper nf2) -> (immersionProper {nf1} cl1 == immersionProper {nf2} cl2) -> nf1 == nf2
+≡immersionProper-n CanZ CanZ p = idp
+≡immersionProper-n (CanS {n1} {S nf1} pn1 cl1 {r1} pr1) CanZ p = ⊥-elim (++-abs-lr p)
+≡immersionProper-n CanZ (CanS {n2} {S nf2} pn2 cl2 {r2} pr2) p = ⊥-elim (++-abs-lr (! p))
+≡immersionProper-n (CanS {n1} {S nf1} pn1 cl1 {r1} pr1) (CanS {n2} {S nf2} pn2 cl2 {r2} pr2) p = 
+  let n1>>cl1 = immersionProper->> cl1
+      n2>>cl2 = immersionProper->> cl2
+      pn , pk , pm = ≡-++↓-Proper _ _ _ _ _ _ (>>-up (≤-down pn1) n1>>cl1) (>>-up (≤-down pn2) n2>>cl2) (≤-down2 pr1) (≤-down2 pr2) p
+  in  ap S pn
+
+
+≡immersionProper-r : {nf1 nf2 : ℕ} -> (cl1 : LehmerProper (S nf1)) -> (cl2 : LehmerProper (S nf2)) -> (immersionProper {S nf1} cl1 == immersionProper {S nf2} cl2) -> (extractProper-r cl1) == (extractProper-r cl2)
+≡immersionProper-r (CanS {n1} {S nf1} pn1 cl1 {r1} pr1) (CanS {n2} {S nf2} pn2 cl2 {r2} pr2) p = 
+  let n1>>cl1 = immersionProper->> cl1
+      n2>>cl2 = immersionProper->> cl2
+      pn , pk , pm = ≡-++↓-Proper _ _ _ _ _ _ (>>-up (≤-down pn1) n1>>cl1) (>>-up (≤-down pn2) n2>>cl2) (≤-down2 pr1) (≤-down2 pr2) p
+  in  pk
 
 
 canonical-proper-append : {n : ℕ} -> (cl : LehmerProper n) -> (x : ℕ) -> (n ≤ x) -> Σ _ (λ clx -> immersionProper {S x} clx == immersionProper {n} cl ++ [ x ])
@@ -274,8 +319,8 @@ is-canonical? (x :: m) with is-canonical? m
         last = cut-prefix ss 
         prefix = cut-last ss
         SSn₁=Snf = ≡immersionProper-n ((CanS (s≤s x₁) fst₁ (≤-up (s≤s x₂)))) (CanS qn cl qr) (prefix ∙ ! pp)
-
-    in  qq (ap S (! last) ∙ (∸-up-r x₂ ∙ ap (λ e -> S n₁ ∸ e) {!   !}) ∙  ap (λ e -> e ∸ r) (≡-down2 SSn₁=Snf))
+        r₁=r₂ = ≡immersionProper-r ((CanS (s≤s x₁) fst₁ (≤-up (s≤s x₂)))) (CanS qn cl qr) (prefix ∙ ! pp)
+    in  qq (ap S (! last) ∙ (∸-up-r x₂ ∙ ap (λ e -> S n₁ ∸ e) r₁=r₂) ∙  ap (λ e -> e ∸ r) (≡-down2 SSn₁=Snf))
   }
 
 canonical-proper-NF : {n : ℕ} -> (cl : LehmerProper n) -> (Σ _ (λ m -> immersionProper {n} cl ≅ m)) -> ⊥

--- a/Pi+/Coxeter/CoxeterN.agda
+++ b/Pi+/Coxeter/CoxeterN.agda
@@ -1,0 +1,94 @@
+{-# OPTIONS --without-K --rewriting #-}
+
+module Pi+.Coxeter.CoxeterN where
+
+open import lib.Base
+open import lib.NType
+open import lib.NType2
+open import lib.PathOver
+open import lib.types.Nat using (_+_; <-ap-S; _<_; _≤_)
+open import lib.types.Sigma
+open import lib.PathGroupoid
+open import lib.Funext
+open import lib.types.Pi
+open import lib.types.Fin
+
+-- open import Pi+.Misc
+-- open import Pi+.Coxeter.Arithmetic
+-- open import Pi+.Coxeter.Lists
+-- open import Pi+.Coxeter.ReductionRel
+-- open import Pi+.Coxeter.MCoxeter
+-- open import Pi+.Coxeter.MCoxeterS
+-- open import Pi+.Coxeter.Diamond
+
+
+module Zero where
+    ⟨_⟩ : ∀ {n} → Fin n → Fin (S n)
+    ⟨_⟩ = Fin-S
+
+    S⟨_⟩ : ∀ {n} → Fin n → Fin (S n)
+    S⟨ k , kltn ⟩ = S k , <-ap-S kltn
+
+    infixr 35 _::_
+
+    data CList : ℕ → Type₀ where
+        nil : ∀ {m} → CList m
+        _::_ : ∀ {m} → Fin (S m) → CList m → CList m
+
+    infixr 50 _++_
+
+    _++_ : ∀ {m} → CList m → CList m → CList m
+    _++_ {m} nil l2 = l2
+    _++_ {m} (x :: l1) l2 = x :: (l1 ++ l2)
+
+    data _≈₀_ {m : ℕ} : CList m → CList m → Type₀ where
+        cancel : {n : Fin (S m)} {w : CList m} → (n :: n :: w) ≈₀ w
+        swap : {n : Fin (S m)} {k : Fin (S m)} → (S (k .fst) < (n .fst)) → {w : CList m} → (n :: k :: w) ≈₀ (k :: n :: w)
+        braid : {n : Fin m} {w : CList m} → (S⟨ n ⟩ :: ⟨ n ⟩ :: S⟨ n ⟩ :: w) ≈₀ (⟨ n ⟩ :: S⟨ n ⟩ :: ⟨ n ⟩ :: w)
+
+        idp : {l : CList m} -> l ≈₀ l
+        comm : {l1 l2 : CList m} -> (l1 ≈₀ l2) -> l2 ≈₀ l1
+        trans : {l1 l2 l3 : CList m} -> (l1 ≈₀ l2) -> (l2 ≈₀ l3) -> l1 ≈₀ l3
+
+        respects-++ : {l l' r r' : CList m} -> (l ≈₀ l') -> (r ≈₀ r') -> l ++ r ≈₀ l' ++ r
+
+
+module One where 
+    open import lib.types.List
+
+    ⟨_⟩ : ∀ {n} → Fin n → Fin (S n)
+    ⟨_⟩ = Fin-S
+
+    S⟨_⟩ : ∀ {n} → Fin n → Fin (S n)
+    S⟨ k , kltn ⟩ = S k , <-ap-S kltn
+
+    data _≈₁_ {m : ℕ} : List (Fin (S m)) → List (Fin (S m)) → Type₀ where
+        cancel : {n : Fin (S m)} → (n :: n :: nil) ≈₁ nil
+        swap : {n : Fin (S m)} {k : Fin (S m)} → (S (k .fst) < (n .fst)) → (n :: k :: nil) ≈₁ (k :: n :: nil)
+        braid : {n : Fin m} → (S⟨ n ⟩ :: ⟨ n ⟩ :: S⟨ n ⟩ :: nil) ≈₁ (⟨ n ⟩ :: S⟨ n ⟩ :: ⟨ n ⟩ :: nil)
+
+        idp : {m : List (Fin (S m))} -> m ≈₁ m
+        comm : {m1 m2 : List (Fin (S m))} -> (m1 ≈₁ m2) -> m2 ≈₁ m1
+        trans : {m1 m2 m3 : List (Fin (S m))} -> (m1 ≈₁ m2) -> (m2 ≈₁ m3) -> m1 ≈₁ m3
+
+        respects-++ : {l l' r r' : List (Fin (S m))} -> (l ≈₁ l') -> (r ≈₁ r') -> l ++ r ≈₁ l' ++ r
+
+
+module Two where
+    open import lib.types.List
+
+    _>>_ : ℕ -> List ℕ -> Type₀
+    n >> l = All (λ x → x < n) l
+
+    data _≈₂[_]_ : List ℕ → ℕ → List ℕ → Type₀ where
+        cancel : {n : ℕ} → (n :: n :: nil) ≈₂[ n ] nil
+        swap : {n : ℕ} {k : ℕ} → (k < n) → (n :: k :: nil) ≈₂[ n ] (k :: n :: nil)
+        braid : {n : ℕ} → (S n :: n :: S n :: nil) ≈₂[ S n ] ( n :: S n :: n :: nil)
+
+        idp : {n : ℕ} → {l : List ℕ} -> (S n >> l) -> l ≈₂[ n ] l
+        comm : {n : ℕ} → {l1 l2 : List ℕ} -> (l1 ≈₂[ n ] l2) -> l2 ≈₂[ n ] l1
+        trans : {n : ℕ} → {l1 l2 l3 : List ℕ} -> (l1 ≈₂[ n ] l2) -> (l2 ≈₂[ n ] l3) -> l1 ≈₂[ n ] l3
+
+        respects-++ : {n : ℕ} {l l' r r' : List ℕ} -> (l ≈₂[ n ] l') -> (r ≈₂[ n ] r') -> l ++ r ≈₂[ n ] l' ++ r
+
+        lift : {n k : ℕ} -> (n ≤ k) -> (l r : List ℕ) -> l ≈₂[ n ] r -> l ≈₂[ k ] r

--- a/Pi+/Coxeter/CoxeterN.agda
+++ b/Pi+/Coxeter/CoxeterN.agda
@@ -35,12 +35,6 @@ module Zero where
         nil : ∀ {m} → CList m
         _::_ : ∀ {m} → Fin (S m) → CList m → CList m
 
-    infixr 50 _++_
-
-    _++_ : ∀ {m} → CList m → CList m → CList m
-    _++_ {m} nil l2 = l2
-    _++_ {m} (x :: l1) l2 = x :: (l1 ++ l2)
-
     data _≈₀_ {m : ℕ} : CList m → CList m → Type₀ where
         cancel : {n : Fin (S m)} {w : CList m} → (n :: n :: w) ≈₀ w
         swap : {n : Fin (S m)} {k : Fin (S m)} → (S (k .fst) < (n .fst)) → {w : CList m} → (n :: k :: w) ≈₀ (k :: n :: w)
@@ -50,7 +44,7 @@ module Zero where
         comm : {l1 l2 : CList m} -> (l1 ≈₀ l2) -> l2 ≈₀ l1
         trans : {l1 l2 l3 : CList m} -> (l1 ≈₀ l2) -> (l2 ≈₀ l3) -> l1 ≈₀ l3
 
-        respects-++ : {l l' r r' : CList m} -> (l ≈₀ l') -> (r ≈₀ r') -> l ++ r ≈₀ l' ++ r
+        respects-:: : {n : Fin (S m)} -> {l l' : CList m} -> (l ≈₀ l') -> n :: l ≈₀ n :: l'
 
 
 module One where 

--- a/Pi+/Coxeter/ImpossibleLists.agda
+++ b/Pi+/Coxeter/ImpossibleLists.agda
@@ -30,7 +30,6 @@ incr-long-lemma-rev : (n k n1 k1 : ℕ) -> (S k1 < n1) -> (l r : List) -> (n ↑
 incr-long-lemma-rev n (S (S k)) .(S n) .n pkn nil .(S (S n) ↑ k) idp = abs-refl pkn
 incr-long-lemma-rev n (S k) n1 k1 pkn (x :: l) r p = incr-long-lemma-rev (S n) k n1 k1 pkn l r (cut-head p)
 
-
 incr-long-lemma : (n k n1 k1 : ℕ) -> (S k1 < n1) -> (l r : List) -> (n ↓ k) == (l ++ n1 :: k1 :: r) -> ⊥
 incr-long-lemma n k n1 k1 p l r q =
   let pp =
@@ -72,9 +71,54 @@ dec-long-lemma n k n1 k1 p l r q =
         =∎
   in  dec-long-lemma-rev n k n1 k1 p (rev r) (rev l) pp
 
-postulate
-  repeat-spaced-long-lemma : (n k n1 : ℕ) -> (l r1 r2 : List) -> (n ↓ k) == (l ++ n1 :: r1 ++ n1 :: r2) -> ⊥
 
+less-than-↓ : (n k o : ℕ) -> (k + n ≤ o) -> (l r : List) -> (n ↓ k) == (l ++ (o :: r)) -> ⊥
+less-than-↓ n O o pko nil r ()
+less-than-↓ n O o pko (x :: l) r ()
+less-than-↓ n (S k) o pko nil r p = 1+n≰n (≤-trans pko (≤-reflexive (! (cut-tail p))))
+less-than-↓ n (S k) o pko (x :: l) r p = less-than-↓ n k o (≤-down pko) l r (cut-head p) 
+
+repeat-spaced-long-lemma : (n k o o1 : ℕ) -> (o ≤ o1) -> (l r1 r2 : List) -> (n ↓ k) == (l ++ (o :: r1) ++ (o1 :: r2)) -> ⊥
+repeat-spaced-long-lemma n O o o1 op nil r1 r2 ()
+repeat-spaced-long-lemma n O o o1 op (x :: l) r1 r2 ()
+repeat-spaced-long-lemma n (S k) o o1 op nil r1 r2 p = 
+  let k+n=o = cut-tail p 
+  in  less-than-↓ n k o1 ((≤-trans (≤-reflexive (cut-tail p)) op)) r1 r2 (cut-head p)
+repeat-spaced-long-lemma n (S k) o o1 op (x :: l) r1 r2 p = repeat-spaced-long-lemma n k o o1 op l r1 r2 (cut-head p)
+
+repeat-spaced2-long-lemma : (n k n1 k1 n2 k2 o : ℕ) -> (S o < k1 + n1) -> (k2 + n2 ≤ o) -> (k + n < k1 + n1) -> (l r : List) -> (n ↓ k) ++ (n1 ↓ k1) == (l ++ (n2 ↓ S k2) ++ o :: r) -> ⊥
+repeat-spaced2-long-lemma n O n1 k1 n2 O o op1 op2 pkn l r p = dec-long-lemma _ _ _ _ op2 _ _ p
+repeat-spaced2-long-lemma n O n1 k1 n2 (S k2) o op1 op2 pkn l r p = repeat-spaced-long-lemma _ _ _ _ op2 _ (n2 ↓ (S k2)) r p
+repeat-spaced2-long-lemma n (S O) n1 (S k1) n2 O o op1 op2 pkn nil r p = 
+  let n=n2 = cut-tail p 
+      k1+n1=o = cut-tail (cut-head p)
+      open ≤-Reasoning
+      lemma =
+         S (S o)
+        ≤⟨ op1 ⟩
+          S (k1 + n1)
+        ≡⟨ ap S k1+n1=o ⟩
+          S o
+        ≤∎
+
+  in  1+n≰n lemma
+repeat-spaced2-long-lemma n (S (S k)) n1 k1 n2 O o op1 op2 pkn nil r p = 
+  let 1+k+n=n2 = cut-tail p 
+      k+n=o = cut-tail (cut-head p)
+  in  1+n≰n (≤-trans (≤-trans (≤-reflexive 1+k+n=n2) op2) (≤-reflexive (! k+n=o)))
+repeat-spaced2-long-lemma n (S k) n1 k1 n2 (S k2) o op1 op2 pkn nil r p = repeat-spaced2-long-lemma n k n1 k1 n2 k2 o op1 (≤-down op2) (≤-down pkn) nil r (cut-head p)
+repeat-spaced2-long-lemma n (S k) n1 k1 n2 k2 o op1 op2 pkn (x :: l) r p = repeat-spaced2-long-lemma n k n1 k1 n2 k2 o op1 op2 (≤-down pkn) l r (cut-head p)
+
+repeat-↓-long-lemma-r : (n k n1 k1 n2 k2 : ℕ) -> (k + n < k1 + n1) -> (r : List) -> (n ↓ k) ++ (n1 ↓ k1) == ((n2 ↓ S k2) ++ (k2 + n2) :: r) -> ⊥
+repeat-↓-long-lemma-r n O n1 k1 n2 k2 pkn r p = repeat-spaced-long-lemma n1 k1 (k2 + n2) (k2 + n2) (≤-reflexive idp) nil (n2 ↓ k2) r p
+repeat-↓-long-lemma-r n (S k) n1 k1 n2 k2 pkn r p = 
+  let lemma = cut-tail p
+  in  repeat-spaced2-long-lemma n (S k) n1 k1 n2 k2 (k2 + n2) (≤-trans (≤-reflexive (ap (λ e -> S (S e)) (! lemma))) pkn) (≤-reflexive idp) pkn nil r p
+
+repeat-↓-long-lemma : (n k n1 k1 n2 k2 : ℕ) -> (k + n < k1 + n1) -> (l r : List) -> (n ↓ k) ++ (n1 ↓ k1) == (l ++ (n2 ↓ S k2) ++ (k2 + n2) :: r) -> ⊥
+repeat-↓-long-lemma n k n1 k1 n2 k2 pkn nil r p = repeat-↓-long-lemma-r n k n1 k1 n2 k2 pkn r p
+repeat-↓-long-lemma n O n1 (S k1) n2 k2 pkn (x :: l) r p = repeat-spaced-long-lemma n1 k1 (k2 + n2) (k2 + n2) (≤-reflexive idp) l (n2 ↓ k2) r (cut-head p)
+repeat-↓-long-lemma n (S k) n1 k1 n2 k2 pkn (x :: l) r p = repeat-↓-long-lemma n k n1 k1 n2 k2 (≤-trans (≤-down (≤-reflexive idp)) pkn) l r (cut-head p)
 
 ++-nonempty-abs : {n : ℕ} -> (l r : List) -> nil == l ++ n :: r -> ⊥
 ++-nonempty-abs {n} nil r = λ ()

--- a/Pi+/Coxeter/Lehmer.agda
+++ b/Pi+/Coxeter/Lehmer.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --allow-unsolved-metas --termination-depth=2 #-}
+{-# OPTIONS --without-K --rewriting --termination-depth=2 #-}
 
 module Pi+.Coxeter.Lehmer where
 

--- a/Pi+/Coxeter/Lehmer.agda
+++ b/Pi+/Coxeter/Lehmer.agda
@@ -191,17 +191,107 @@ immersion->> {S n} (CanS {n} cl {r} rn) =
   let p = immersion->> {n} cl
   in  >>-++ (>>-S p) (>>-↓ (S n) (S n ∸ r) r (≤-reflexive (plus-minus rn)))
 
+tlm : {n : ℕ} -> (cl : Lehmer n) -> (k m rl : ℕ) -> (x : S rl ≤ S n) -> (l : List) -> (S (k + m) ≤ n ∸ S rl) -> (l ++ S (k + m) :: k + m :: m ↓ k == immersion (CanS cl {S rl} x)) -> ⊥
+tlm {n} cl k m O x l pkmr p = 
+  let 0<n = 
+          ≤begin
+            S O
+          ≤⟨ ≤-up2 z≤n ⟩
+            S (k + m)
+          ≤⟨ pkmr ⟩
+            n ∸ 1
+          ≤⟨ ∸-anti-≤ {1} {0} {n} z≤n ⟩ 
+            n
+          ≤∎
+
+      lemma2 = ++-assoc l (k + S m :: S m ↓ k) [ m ] ∙ ap (λ e → l ++ e) (++-↓ m (S k))
+      lemma3 = cut-prefix (! p ∙ ! lemma2)
+      lemma4 =
+          ≤begin
+            S n
+          ≡⟨ ap S lemma3 ⟩
+            S m
+          ≤⟨ ≤-up2 (≤-up (≤-up-+ rrr)) ⟩
+            S (S (k + m))
+          ≤⟨ ≤-up2 pkmr ⟩
+            S (n ∸ 1)
+          ≡⟨ ! (∸-up {n} {0} 0<n) ⟩ 
+            n
+          ≤∎
+
+  in  1+n≰n lemma4
+tlm {n} cl O m (S rl) x l pkmr p = 
+  let lemma1 = (++-assoc (immersion cl) (rl + S (n ∸ S rl) :: S (n ∸ S rl) ↓ rl) [ n ∸ S rl ])
+      lemma2 = ap (λ e -> immersion cl ++ e) (++-↓ (n ∸ S rl) (S rl)) ∙ ! p ∙ ! (++-assoc l (S m :: nil) [ m ])
+      lemma3 = cut-prefix (lemma1 ∙ lemma2)
+      lemma4 = cut-last (lemma1 ∙ lemma2)
+
+      lemma5 = 
+            ≤begin
+              S (n ∸ S (S rl))
+            ≤⟨ ≤-up2 (∸-anti-≤ {S (S rl)} {S rl} {n} (≤-up rrr)) ⟩ 
+              S (n ∸ S rl)
+            ≡⟨ ap S lemma3 ⟩ 
+              S m
+            ≤⟨ pkmr ⟩
+              n ∸ S (S rl)
+            ≤∎
+  in  1+n≰n lemma5
+tlm {n} cl (S k) m (S rl) x l pkmr p = 
+  let lemma1 = (++-assoc (immersion cl) (rl + S (n ∸ S rl) :: S (n ∸ S rl) ↓ rl) [ n ∸ S rl ])
+      lemma2 = ap (λ e → l ++ e) (++-↓ m (S (S k)))
+      lemma3 = ap (λ e -> immersion cl ++ e) (++-↓ (n ∸ S rl) (S rl)) ∙ ! p ∙ ! lemma2 ∙ ! (++-assoc l ((S k) + S m :: S m ↓ (S k)) [ m ])
+      lemma4 = cut-prefix (lemma1 ∙ lemma3)
+      lemma5 = cut-last (lemma1 ∙ lemma3)
+      lemma6 = 
+        ≤begin
+          S (k + S m)
+        ≡⟨ +-three-assoc {S k} {1} {m} ⟩ 
+          S (S (k + m))
+        ≤⟨ pkmr ⟩
+          n ∸ S (S rl)
+        ≤⟨ ∸-anti-≤ {S (S rl)} {S rl} {n} (s≤s (≤-up rrr)) ⟩
+          n ∸ S rl
+        ≤∎
+  in  tlm cl k (S m) rl (≤-down x) l lemma6 (! lemma5 ∙ transport (λ e -> immersion cl ++ rl + e :: e ↓ rl == immersion cl ++ rl + n ∸ rl :: n ∸ rl ↓ rl) (∸-up x) idp)
+
+immersion-long-lemma : {n : ℕ} -> (cl : Lehmer n) -> (k m : ℕ) -> (l r : List) -> (immersion cl == l ++ S (k + m) :: k + m :: (m ↓ k ++ S (k + m) :: (rev r))) -> ⊥
+immersion-long-lemma {.0} CanZ k m nil r ()
+immersion-long-lemma {.0} CanZ k m (x :: l) r ()
+immersion-long-lemma {.(S _)} (CanS cl {O} x) k m l r dfm = immersion-long-lemma cl k m l r (! ++-unit ∙ dfm)
+immersion-long-lemma {S n} (CanS cl {S O} x) k m l nil dfm = 
+  let lemma2 = ! (++-assoc l (S (k + m) :: k + m :: (m ↓ k)) (S (k + m) :: nil))
+      lemma3 = cut-prefix ((! lemma2 ∙ ! dfm))
+      lemma4 = cut-last ((! lemma2 ∙ ! dfm))
+      lemma6 = transport (λ e -> immersion cl ++ e == (l ++ S (k + m) :: k + m :: m ↓ k) ++ S (k + m) :: nil) (ap [_] lemma3) (ap (λ e -> e ++ [ S (k + m) ]) (! lemma4))
+  in  >>-⊥ n (S (k + m)) (≤-reflexive (! lemma3)) (immersion cl) l (k + m :: (m ↓ k)) (immersion->> cl) (cut-last lemma6)
+immersion-long-lemma {S n} (CanS cl {S (S rl)} x) k m l nil dfm =
+  let lemma1 = ap (λ e -> immersion cl ++ e) (! (++-↓ (n ∸ S rl) (S rl)))
+      lemma2 = ! (++-assoc l (S (k + m) :: k + m :: (m ↓ k)) (S (k + m) :: nil))
+      lemma3 = cut-prefix ((! lemma2 ∙ ! dfm) ∙ lemma1  ∙ ! (++-assoc (immersion cl) (rl + S (n ∸ S rl) :: S (n ∸ S rl) ↓ rl) [ n ∸ S rl ]))
+      lemma4 = cut-last ((! lemma2 ∙ ! dfm) ∙ lemma1  ∙ ! (++-assoc (immersion cl) (rl + S (n ∸ S rl) :: S (n ∸ S rl) ↓ rl) [ n ∸ S rl ]))
+  in  tlm cl k m rl (≤-down x) l (≤-reflexive lemma3) (lemma4 ∙ ap (λ e -> immersion cl ++ rl + e :: e ↓ rl) (! (∸-up x)))
+immersion-long-lemma {(S n)} (CanS cl {S rl} x) k m l (x₁ :: r) dfm = 
+  let lemma1 = ap (λ e -> immersion cl ++ e) (! (++-↓ (n ∸ rl) rl))
+      lemma2 = ! (++-assoc l (S (k + m) :: k + m :: (m ↓ k)) (S (k + m) :: (rev r ++ [ x₁ ]))) ∙ ! (++-assoc (l ++ S (k + m) :: k + m :: m ↓ k) (S (k + m) :: rev r) [ x₁ ])
+      lemma3 = cut-prefix ((! lemma2 ∙ ! dfm) ∙ lemma1  ∙ ! (++-assoc (immersion cl) _ [ n ∸ rl ]))
+      lemma4 = cut-last ((! lemma2 ∙ ! dfm) ∙ lemma1  ∙ ! (++-assoc (immersion cl) _ [ n ∸ rl ]))
+      lemma5 = ++-assoc l (S (k + m) :: k + m :: m ↓ k) (S (k + m) :: rev r)
+  in  immersion-long-lemma (CanS cl {rl} (≤-down x)) k m l r ((ap (λ e -> immersion cl ++ e ↓ rl) (∸-up x) ∙ ! lemma4) ∙ lemma5)
+
 {-# NON_TERMINATING #-}
 final≅-Lehmer : {n : ℕ} -> (cl : Lehmer n) -> (m mf : List) -> (defm : m == (immersion {n} cl)) -> m ≅ mf -> ⊥
 final≅-Lehmer {O} CanZ nil mf defm p = empty-reduction p
 final≅-Lehmer {S O} (CanS CanZ {O} x) nil mf defm p = empty-reduction p
 final≅-Lehmer {S O} (CanS CanZ {S .0} (s≤s z≤n)) (x :: nil) mf defm p = one-reduction p
-final≅-Lehmer {S (S n)} (CanS (CanS cl {r₁} x₁) {r₂} x₂) m mf defm (cancel≅ {n₁} l r .m .mf defm₁ defmf) with (lemma-l++2++r n₁ n₁ ((immersion cl ++ S n ∸ r₁ ↓ r₁)) (S (S n) ∸ r₂ ↓ r₂) l r ((! defm) ∙ defm₁))
+final≅-Lehmer {S (S n)} (CanS (CanS cl {r₁} x₁) {r₂} x₂) m mf defm (cancel≅ {n₁} l r .m .mf defm₁ defmf) 
+  with (lemma-l++2++r n₁ n₁ ((immersion cl ++ S n ∸ r₁ ↓ r₁)) (S (S n) ∸ r₂ ↓ r₂) l r ((! defm) ∙ defm₁))
 ... | R1 ((fst₁ , snd₁) , fst₂ , fst₃ , snd₂) = final≅-Lehmer {S n} (CanS cl {r₁} x₁) _ _ idp (cancel≅ _ _ _ _ fst₃ idp)
 ... | R2 ((fst₁ , snd₁) , fst₂ , fst₃ , snd₂) = final≅-↓ (S (S n) ∸ r₂) r₂ _ (cancel≅ _ _ _ _ snd₂ idp)
 final≅-Lehmer {S (S n)} (CanS (CanS cl {r₁} x₁) {S r₂} x₂) m mf defm (cancel≅ {n₁} l r .m .mf defm₁ defmf) | R3 (fst₁ , snd₁) = 
   >>-⊥ (S n) n₁ (≤-reflexive (! (plus-minus (≤-down2 x₂)) ∙ (cut-tail snd₁))) (immersion (CanS cl {r₁} x₁)) l nil (immersion->> (CanS cl {r₁} x₁)) fst₁
-final≅-Lehmer {S (S n)} (CanS (CanS cl {r₁} x₁) {r₂} x₂) m mf defm (swap≅ {n₁} {k₁} ps l r .m .mf defm₁ defmf) with (lemma-l++2++r n₁ k₁ ((immersion cl ++ S n ∸ r₁ ↓ r₁)) (S (S n) ∸ r₂ ↓ r₂) l r ((! defm) ∙ defm₁))
+final≅-Lehmer {S (S n)} (CanS (CanS cl {r₁} x₁) {r₂} x₂) m mf defm (swap≅ {n₁} {k₁} ps l r .m .mf defm₁ defmf) 
+  with (lemma-l++2++r n₁ k₁ ((immersion cl ++ S n ∸ r₁ ↓ r₁)) (S (S n) ∸ r₂ ↓ r₂) l r ((! defm) ∙ defm₁))
 ... | R1 ((fst₁ , snd₁) , fst₂ , fst₃ , snd₂) = final≅-Lehmer {S n} (CanS cl {r₁} x₁) _ _ idp (swap≅ ps _ _ _ _ fst₃ idp)
 ... | R2 ((fst₁ , snd₁) , fst₂ , fst₃ , snd₂) = final≅-↓ (S (S n) ∸ r₂) r₂ _ (swap≅ ps _ _ _ _ snd₂ idp)
 final≅-Lehmer {S (S n)} (CanS (CanS cl {r₁} x₁) {S r₂} x₂) m mf defm (swap≅ {n₁} {k₁} ps l r .m .mf defm₁ defmf) | R3 (fst₁ , snd₁) =
@@ -216,10 +306,9 @@ final≅-Lehmer {S (S n)} (CanS (CanS cl {r₁} x₁) {S r₂} x₂) m mf defm (
             n₁
           ≤∎
   in  >>-⊥ (S n) n₁ (≤-down (≤-down lemma)) (immersion (CanS cl {r₁} x₁)) l nil (immersion->> (CanS cl {r₁} x₁)) fst₁
-final≅-Lehmer {S (S n)} (CanS (CanS cl {r₁} x₁) {r₂} x₂) m mf defm (long≅ {n₁} k l r .m .mf defm₁ defmf) 
-  with (lemma-l++1++r (S (k + n₁)) (immersion (CanS cl {r₁} x₁)) (S (S n) ∸ r₂ ↓ r₂) (l ++ S (k + n₁) :: k + n₁ :: (n₁ ↓ k)) r ((! defm) ∙ defm₁ ∙ ! (++-assoc l _ _)))
-... | inl ((fst₁ , snd₁) , fst₂ , fst₃ , snd₂) = final≅-Lehmer {S n} (CanS cl {r₁} x₁) _ _ idp (long≅ {n₁} k l fst₁ _ _ (fst₃ ∙ (++-assoc l _ _)) idp)
-final≅-Lehmer {S (S n)} (CanS (CanS cl {r₁} x₁) {r₂} x₂) m mf defm (long≅ {n₁} k l r .m .mf defm₁ defmf) | inr ((fst₁ , snd₁) , fst₂ , fst₃ , snd₂) = {!   !}
+final≅-Lehmer {S (S n)} (CanS (CanS cl {r₁} x₁) {r₂} x₂) m mf defm (long≅ {n₁} k l r .m .mf defm₁ defmf) = 
+  let lemma = transport (λ e -> l ++ S (k + n₁) :: k + n₁ :: (n₁ ↓ k ++ S (k + n₁) :: e) == l ++ S (k + n₁) :: k + n₁ :: (n₁ ↓ k ++ S (k + n₁) :: rev (rev r))) (! rev-rev) idp
+  in  immersion-long-lemma (CanS (CanS cl x₁) x₂) k n₁ l (rev r) ( (! defm) ∙ defm₁ ∙ lemma)
 
 ≡-↓ : (n k1 k2 : ℕ) -> (k1 ≤ n) -> (k2 ≤ n) -> ((n ↓ k1) == (n ↓ k2)) -> (k1 == k2)
 ≡-↓ n O O pk1 pk2 r = idp
@@ -255,16 +344,16 @@ final≅-Lehmer {S (S n)} (CanS (CanS cl {r₁} x₁) {r₂} x₂) m mf defm (lo
 
 only-one-canonical≅* : {n : ℕ} -> (cl1 cl2 : Lehmer n) -> (m1 m2 : List) -> (immersion {n} cl1 == m1) -> (immersion {n} cl2 == m2) -> (m1 ≅* m2)-> cl1 == cl2
 only-one-canonical≅* cl1 cl2 m1 .m1 pm1 pm2 idp = ≡immersion _ _ (≡-trans pm1 (≡-sym pm2))
-only-one-canonical≅* cl1 cl2 m1 m2 pm1 pm2 (trans≅ x p) =
+only-one-canonical≅* {n} cl1 cl2 m1 m2 pm1 pm2 (trans≅ x p) =
   let ss = transport (λ t → t ≅ _) (! pm1) x
-  in  ⊥-elim (final≅-Lehmer cl1 (immersion cl1) _ idp ss)
+  in  ⊥-elim (final≅-Lehmer cl1 (immersion {n} cl1) _ idp ss)
 
 only-one-canonical≃ : {n : ℕ} -> (cl1 cl2 : Lehmer n) -> (m1 m2 : List) -> (immersion {n} cl1 == m1) -> (immersion {n} cl2 == m2) -> (m1 ≃ m2) -> cl1 == cl2
 only-one-canonical≃ cl1 cl2 m1 .m1 pm1 pm2 (comm≅ idp idp) = ≡immersion _ _ (≡-trans pm1 (≡-sym pm2))
-only-one-canonical≃ cl1 cl2 m1 m2 pm1 pm2 (comm≅ idp (trans≅ x p2)) =
+only-one-canonical≃ {n} cl1 cl2 m1 m2 pm1 pm2 (comm≅ idp (trans≅ x p2)) =
   let ss = transport (λ t → t ≅ _) (≡-sym pm2) x
   in  ⊥-elim (final≅-Lehmer cl2 _ _ idp ss)
-only-one-canonical≃ cl1 cl2 m1 m2 pm1 pm2 (comm≅ (trans≅ x p1) p2) =
+only-one-canonical≃ {n} cl1 cl2 m1 m2 pm1 pm2 (comm≅ (trans≅ x p1) p2) =
   let ss = transport (λ t → t ≅ _) (≡-sym pm1) x
   in  ⊥-elim (final≅-Lehmer cl1 _ _ idp ss)
 

--- a/Pi+/Coxeter/Lehmer.agda
+++ b/Pi+/Coxeter/Lehmer.agda
@@ -61,7 +61,7 @@ final≅-↓ : (n k1 : ℕ) -> (m : List) -> (n ↓ k1) ≅ m -> ⊥
 final≅-↓ n k1 m (cancel≅ {n₁} l r .(n ↓ k1) .m defm defmf) = repeat-long-lemma n k1 n₁ l r defm
 final≅-↓ n k1 m (swap≅ x l r .(n ↓ k1) .m defm defmf) = incr-long-lemma _ _ _ _ x l r defm
 final≅-↓ n k1 m (long≅ {n₁} k l r .(n ↓ k1) .m defm defmf) =
-  repeat-spaced-long-lemma n k1 (S (k + n₁)) l ((n₁ ↓ (1 + k))) r defm
+  repeat-spaced-long-lemma n k1 ((S (k + n₁))) (S (k + n₁)) (≤-reflexive idp) l (((n₁ ↓ (1 + k)))) r defm
 
 -- a helper trichotomy type
 data _||_||_ (A : Type₀) (B : Type₀) (C : Type₀) : Type₀ where
@@ -87,16 +87,61 @@ lemma-l++2++r a b (x :: l1) r1 (x₁ :: l2) r2 p with lemma-l++2++r a b l1 r1 l2
 ... | R2 ((fst , snd) , fst₁ , fst₂ , snd₁) = R2 (((x₁ :: fst) , snd) , ((cong (λ e -> x₁ :: e) fst₁) , ((head+tail (cut-tail p) fst₂) , snd₁)))
 ... | R3 (fst , snd) = R3 (head+tail (cut-tail p) fst , snd)
 
+last-↓ : (n k o : ℕ) -> (l : List) -> (n ↓ k == l ++ [ o ]) -> (n == o)
+last-↓ n (S O) o nil p = cut-tail p
+last-↓ n (S k) o (x :: l) p = last-↓ n k o l (cut-head p)
+
 final≅-↓-↓ : (n k n1 k1 : ℕ) -> (m : List) -> (k + n < k1 + n1) -> ((n ↓ k) ++ (n1 ↓ k1)) ≅ m -> ⊥
 final≅-↓-↓ n k n1 k1 m pkn (cancel≅ {n₁} l r .((n ↓ k) ++ (n1 ↓ k1)) .m defm defmf) with (lemma-l++2++r n₁ n₁ (n ↓ k) (n1 ↓ k1) l r defm)
 final≅-↓-↓ n k n1 k1 m pkn (cancel≅ {n₁} l r .(n ↓ k ++ n1 ↓ k1) .m defm defmf) | R1 (x , fst₁ , fst₂ , snd₁) = 
     dec-long-lemma n k n₁ n₁ (≤-reflexive idp) l (fst x) fst₂
 final≅-↓-↓ n k n1 k1 m pkn (cancel≅ {n₁} l r .(n ↓ k ++ n1 ↓ k1) .m defm defmf) | R2 (x , fst₁ , fst₂ , snd₁) = 
     dec-long-lemma n1 k1 n₁ n₁ (≤-reflexive idp) (snd x) r snd₁
-final≅-↓-↓ n k n1 k1 m pkn (cancel≅ {n₁} l r .(n ↓ k ++ n1 ↓ k1) .m defm defmf) | R3 x = {!   !}
+final≅-↓-↓ n O n1 (S k1) m pkn (cancel≅ {n₁} nil r .(n ↓ O ++ n1 ↓ S k1) .m defm defmf) | R3 (() , snd₁)
+final≅-↓-↓ n O n1 (S k1) m pkn (cancel≅ {n₁} (x :: l) r .(n ↓ O ++ n1 ↓ S k1) .m defm defmf) | R3 (() , snd₁)
+final≅-↓-↓ n (S k) n1 (S k1) m pkn (cancel≅ {o} l r .(n ↓ S k ++ n1 ↓ S k1) .m defm defmf) | R3 (fst₁ , snd₁) = 
+  let k1+n1=o = cut-tail snd₁
+      n=o = last-↓ _ _ _ _ fst₁
+      open ≤-Reasoning
+      lemma =
+        ≤begin
+          S (S o)
+        ≡⟨ ap (λ e -> S (S e)) (≡-sym n=o) ⟩ 
+         S (S n) 
+        ≤⟨ ≤-up2 (≤-up2 (≤-up-+ (≤-reflexive idp))) ⟩ 
+          S (S (k + n))
+        ≤⟨ pkn ⟩ 
+          S (k1 + n1)
+        ≡⟨ ap S k1+n1=o ⟩ 
+          S o
+        ≤∎
+  in  ⊥-elim (1+n≰n lemma)
 final≅-↓-↓ n k n1 k1 m pkn (swap≅ x l r .((n ↓ k) ++ (n1 ↓ k1)) .m defm defmf) with (lemma-l++2++r _ _ (n ↓ k) (n1 ↓ k1) l r defm)
-... | q = {!   !}
-final≅-↓-↓ n k n1 k1 m pkn (long≅ k₁ l r .((n ↓ k) ++ (n1 ↓ k1)) .m defm defmf) = {!   !}
+... | R1 (q , fst₁ , fst₂ , snd₁) = incr-long-lemma n k _ _ x l (fst q) fst₂
+... | R2 (q , fst₁ , fst₂ , snd₁) = incr-long-lemma n1 k1 _ _ x (snd q) r snd₁
+final≅-↓-↓ n O n1 (S k1) m pkn (swap≅ x nil r .(n ↓ O ++ n1 ↓ S k1) .m defm defmf) | R3 (() , snd₁)
+final≅-↓-↓ n O n1 (S k1) m pkn (swap≅ x (x₁ :: l) r .(n ↓ O ++ n1 ↓ S k1) .m defm defmf) | R3 (() , snd₁)
+final≅-↓-↓ n (S k) n1 (S k1) m pkn (swap≅ {wn} {wk} x l r .(n ↓ S k ++ n1 ↓ S k1) .m defm defmf) | R3 (fst₁ , snd₁) = 
+    let k1+n1=wk = cut-tail snd₁
+        n=wn = last-↓ _ _ _ _ fst₁
+        open ≤-Reasoning
+        lemma =
+          ≤begin
+            S (S (S (S wk)))
+          ≤⟨ ≤-up2 (≤-up2 x) ⟩
+            S (S wn)
+          ≡⟨ ap (λ e -> S (S e)) (≡-sym n=wn) ⟩ 
+          S (S n)
+          ≤⟨ ≤-up2 (≤-up2 (≤-up-+ (≤-reflexive idp))) ⟩ 
+            S (S (k + n))
+          ≤⟨ pkn ⟩ 
+            S (k1 + n1)
+          ≡⟨ ap S k1+n1=wk ⟩ 
+            S wk
+          ≤∎
+  in  ⊥-elim (1+n≰n (≤-down (≤-down lemma)))
+final≅-↓-↓ n k n1 k1 m pkn (long≅ k₁ l r .((n ↓ k) ++ (n1 ↓ k1)) .m defm defmf) = 
+  repeat-↓-long-lemma n k n1 k1 _ (S k₁) pkn l r defm
 
 ++-assoc-≡ : {l r1 r2 m : List} -> m == ((l ++ r1) ++ r2) -> m == (l ++ (r1 ++ r2))
 ++-assoc-≡ {l} {r1} {r2} {m} p = ≡-trans p (++-assoc l r1 r2)
@@ -115,12 +160,10 @@ final≅-Lehmer {S (S n)} (CanS (CanS cl x₁) x) m mf defm (long≅ k l r .m .m
 
 
 ≡-↓ : (n k1 k2 : ℕ) -> (k1 ≤ n) -> (k2 ≤ n) -> ((n ↓ k1) == (n ↓ k2)) -> (k1 == k2)
-≡-↓ 0 .0 .0 z≤n z≤n p = idp
-≡-↓ (S n) 0 0 pk1 pk2 p = idp
-≡-↓ (S n) (S k1) (S k2) pk1 pk2 p =
-  let lemma = (cut-head p)
-      rec = ≡-↓ _ _ _ (≤-down2 pk1) (≤-down2 pk2) {!!}
-  in  cong S rec
+≡-↓ n O O pk1 pk2 r = idp
+≡-↓ n (S k1) (S k2) pk1 pk2 r = 
+   let rec = ≡-↓ _ _ _ (≤-down pk1) (≤-down pk2) (cut-head r)
+   in  cong S rec
 
 ≡-++↓ : (m1 m2 : List) -> (n k1 k2 : ℕ) -> (ml1 : n >> m1) -> (ml2 : n >> m2) -> (k1 ≤ S n) -> (k2 ≤ S n) -> (m1 ++ ((S n ∸ k1) ↓ k1) == m2 ++ ((S n ∸ k2) ↓ k2)) -> (k1 == k2) × (m1 == m2)
 ≡-++↓ nil nil n O O ml1 ml2 pk1 pk2 p = idp , idp

--- a/Pi+/Coxeter/Lehmer.agda
+++ b/Pi+/Coxeter/Lehmer.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --without-K --rewriting --allow-unsolved-metas #-}
+{-# OPTIONS --without-K --rewriting --allow-unsolved-metas --termination-depth=2 #-}
 
 module Pi+.Coxeter.Lehmer where
 
@@ -279,7 +279,6 @@ immersion-long-lemma {(S n)} (CanS cl {S rl} x) k m l (x₁ :: r) dfm =
       lemma5 = ++-assoc l (S (k + m) :: k + m :: m ↓ k) (S (k + m) :: rev r)
   in  immersion-long-lemma (CanS cl {rl} (≤-down x)) k m l r ((ap (λ e -> immersion cl ++ e ↓ rl) (∸-up x) ∙ ! lemma4) ∙ lemma5)
 
-{-# NON_TERMINATING #-}
 final≅-Lehmer : {n : ℕ} -> (cl : Lehmer n) -> (m mf : List) -> (defm : m == (immersion {n} cl)) -> m ≅ mf -> ⊥
 final≅-Lehmer {O} CanZ nil mf defm p = empty-reduction p
 final≅-Lehmer {S O} (CanS CanZ {O} x) nil mf defm p = empty-reduction p

--- a/Pi+/Coxeter/Lehmer.agda
+++ b/Pi+/Coxeter/Lehmer.agda
@@ -42,10 +42,10 @@ canonical-lift {n} .(S (fst + n)) p cln | S fst , idp =
   let rec-m , rec-p = canonical-lift {n} (fst + n) (≤-up-+ rrr) cln
   in  (CanS rec-m z≤n) , (≡-trans ++-unit rec-p)
 
-canonical-append : {n : ℕ} -> (cl : Lehmer n) -> (x : ℕ) -> (n ≤ x) -> Σ _ (λ clx -> immersion {S x} clx == immersion {n} cl ++ [ x ])
+canonical-append : {n : ℕ} -> (cl : Lehmer n) -> (x : ℕ) -> (n ≤ x) -> Σ (Lehmer x) (λ clx -> immersion {S x} (CanS {x} clx {1} (≤-up2 z≤n)) == immersion {n} cl ++ [ x ])
 canonical-append cl x px =
   let lifted-m , lifted-p = canonical-lift x px cl
-  in  CanS lifted-m (s≤s z≤n) , start+end lifted-p idp
+  in  lifted-m , start+end lifted-p idp
 
 lehmer-eta : {n : ℕ} -> {cl1 cl2 : Lehmer n} -> {r1 r2 : ℕ} -> (rn1 : r1 ≤ (S n)) -> (rn2 : r2 ≤ (S n)) -> (cl1 == cl2) -> (r1 == r2) -> (CanS cl1 rn1) == (CanS cl2 rn2)
 lehmer-eta rn1 rn2 idp idp = ap (CanS _) (prop-has-all-paths rn1 rn2) -- TODO: write with ap/uncurry, without path induction

--- a/Pi+/Coxeter/Lehmer.agda
+++ b/Pi+/Coxeter/Lehmer.agda
@@ -219,8 +219,7 @@ final≅-Lehmer {S (S n)} (CanS (CanS cl {r₁} x₁) {S r₂} x₂) m mf defm (
 final≅-Lehmer {S (S n)} (CanS (CanS cl {r₁} x₁) {r₂} x₂) m mf defm (long≅ {n₁} k l r .m .mf defm₁ defmf) 
   with (lemma-l++1++r (S (k + n₁)) (immersion (CanS cl {r₁} x₁)) (S (S n) ∸ r₂ ↓ r₂) (l ++ S (k + n₁) :: k + n₁ :: (n₁ ↓ k)) r ((! defm) ∙ defm₁ ∙ ! (++-assoc l _ _)))
 ... | inl ((fst₁ , snd₁) , fst₂ , fst₃ , snd₂) = final≅-Lehmer {S n} (CanS cl {r₁} x₁) _ _ idp (long≅ {n₁} k l fst₁ _ _ (fst₃ ∙ (++-assoc l _ _)) idp)
-... | inr ((fst₁ , snd₁) , fst₂ , fst₃ , snd₂) = {!   !}
-
+final≅-Lehmer {S (S n)} (CanS (CanS cl {r₁} x₁) {r₂} x₂) m mf defm (long≅ {n₁} k l r .m .mf defm₁ defmf) | inr ((fst₁ , snd₁) , fst₂ , fst₃ , snd₂) = {!   !}
 
 ≡-↓ : (n k1 k2 : ℕ) -> (k1 ≤ n) -> (k2 ≤ n) -> ((n ↓ k1) == (n ↓ k2)) -> (k1 == k2)
 ≡-↓ n O O pk1 pk2 r = idp

--- a/Pi+/Coxeter/Lists.agda
+++ b/Pi+/Coxeter/Lists.agda
@@ -98,6 +98,10 @@ n ↑ (S k) = n :: (S n ↑ k)
 ++-↓ n 0 = idp
 ++-↓ n (S k) rewrite ++-↓ n k = head+tail (+-three-assoc {k} {1} {n}) idp
 
+++-↓-S : (n k x : ℕ) -> (S x == n) -> ((n ↓ k) ++ [ x ]) == (x ↓ (S k))
+++-↓-S n O x p = idp
+++-↓-S n (S k) x p rewrite (! p) rewrite ++-↓ n k = head+tail (+-three-assoc {k} {1} {x}) (++-↓ x k)
+
 ++-↑ : (n k : ℕ) -> ((n ↑ k) ++ [ k + n ]) == (n ↑ (S k))
 ++-↑ n 0 = idp
 ++-↑ n (S k) rewrite ≡-sym (++-↑ (S n) k) rewrite (+-three-assoc {k} {1} {n}) = idp

--- a/Pi+/Coxeter/Lists.agda
+++ b/Pi+/Coxeter/Lists.agda
@@ -85,6 +85,21 @@ head+tail idp idp = idp
 start+end : {h1 h2 : List} -> {t1 t2 : List} -> (h1 == h2) -> (t1 == t2) -> (h1 ++ t1) == (h2 ++ t2)
 start+end idp idp = idp
 
+cut-last : {a1 a2 : ℕ} -> {l1 l2 : List} -> (l1 ++ [ a1 ] == l2 ++ [ a2 ]) -> (l1 == l2)
+cut-last {a1} {.a1} {nil} {nil} idp = idp
+cut-last {a1} {a2} {nil} {x :: nil} ()
+cut-last {a1} {a2} {nil} {x :: x₁ :: l2} ()
+cut-last {a1} {a2} {x :: nil} {nil} ()
+cut-last {a1} {a2} {x :: x₁ :: l1} {nil} ()
+cut-last {a1} {a2} {x :: l1} {x₁ :: l2} p = head+tail (cut-tail p) (cut-last (cut-head p))
+
+cut-prefix : {a1 a2 : ℕ} -> {l1 l2 : List} -> (l1 ++ [ a1 ] == l2 ++ [ a2 ]) -> (a1 == a2)
+cut-prefix {a1} {.a1} {nil} {nil} idp = idp
+cut-prefix {a1} {a2} {nil} {x :: nil} ()
+cut-prefix {a1} {a2} {nil} {x :: x₁ :: l2} ()
+cut-prefix {a1} {a2} {x :: nil} {nil} ()
+cut-prefix {a1} {a2} {x :: x₁ :: l1} {nil} ()
+cut-prefix {a1} {a2} {x :: l1} {x₁ :: l2} p = cut-prefix (cut-head p)
 
 ↓-+ : (n k1 k2 : ℕ) -> (n ↓ (k1 + k2)) == ((n + k2) ↓ k1) ++ (n ↓ k2)
 ↓-+ n 0 k2 = idp

--- a/Pi+/Coxeter/Lists.agda
+++ b/Pi+/Coxeter/Lists.agda
@@ -191,6 +191,10 @@ nil-abs ()
 ++-abs {x} {nil} ()
 ++-abs {x} {x₁ :: l} p = nil-abs p
 
+++-abs-lr : {x : ℕ} -> {l r : List} -> l ++ x :: r == nil -> ⊥
+++-abs-lr {x} {nil} ()
+++-abs-lr {x} {x₁ :: l} p = nil-abs p
+
 _↓↓_,_ : (n : ℕ) -> (k : ℕ) -> (k ≤ n) -> List
 n ↓↓ 0 , z≤n = nil
 S n ↓↓ S k , s≤s p = n :: (n ↓↓ k , p)

--- a/Pi+/Coxeter/README.md
+++ b/Pi+/Coxeter/README.md
@@ -60,4 +60,7 @@ Lehmer equivalence:
   - `ExchangeLemmas+.agda`
     - The analogue of `ExchangeLemmas.agda`, but with a stronger conditions that the reductions should be at least 1-step long.
   - `CanonicalForm.agda`
-    - Defines a `LehmerProper` type - an analogue to `Lehmer`, but it's now keeping just the non-empty . They can be converted from and back to normal Lehmer, but it's not an equivalence.
+    - Defines a `LehmerProper` type - an analogue to `Lehmer`, but it's now keeping just the non-empty indices. They can be converted from and back to normal Lehmer, but it's not an equivalence.
+    - Proves that whether something is an immersion of `LehmerProper` is decidable.
+    - Proves that everything reduces to an image of `LehmerProper` (this this is the canonical form).
+    - Converts that proof to the proof that everything reduces to an image of `Lehmer`.

--- a/Pi+/Level0.agda
+++ b/Pi+/Level0.agda
@@ -121,12 +121,26 @@ slide-transpos {O} (S n , np) (S k , ltSR ()) (ltSR lp)
 slide-transpos {S m} (O , np) (O , kp) ()
 slide-transpos {S m} (O , np) (S k , kp) ()
 slide-transpos {S m} (S .1 , np) (O , kp) ltS =
-  (id⟷₁ ⊕ (id⟷₁ ⊕ transpos2pi (0 , <-cancel-S (<-cancel-S np)))) ◎ (assocl₊ ◎ (swap₊ ⊕ id⟷₁) ◎ assocr₊)
-    ⟷₂⟨ {!!} ⟩
-  (assocl₊ ◎ ((id⟷₁ ⊕ id⟷₁) ⊕ transpos2pi (0 , <-cancel-S (<-cancel-S np)))) ◎
-  ((swap₊ ⊕ id⟷₁) ◎ assocr₊)
-    ⟷₂⟨ {!!} ⟩
-  (assocl₊ ◎ (swap₊ ⊕ id⟷₁) ◎ assocr₊) ◎ (id⟷₁ ⊕ (id⟷₁ ⊕ transpos2pi (0 , _))) ⟷₂∎
+  let tr0 = transpos2pi (0 , <-cancel-S (<-cancel-S np))
+  in (id⟷₁ ⊕ (id⟷₁ ⊕ tr0)) ◎ (assocl₊ ◎ (swap₊ ⊕ id⟷₁) ◎ assocr₊)
+       ⟷₂⟨ trans⟷₂ assoc◎l (assocl₊l ⊡ id⟷₂) ⟩
+     (assocl₊ ◎ ((id⟷₁ ⊕ id⟷₁) ⊕ tr0)) ◎ ((swap₊ ⊕ id⟷₁) ◎ assocr₊)
+       ⟷₂⟨ assoc◎r ⟩
+     assocl₊ ◎ ((id⟷₁ ⊕ id⟷₁) ⊕ tr0) ◎ (swap₊ ⊕ id⟷₁) ◎ assocr₊
+       ⟷₂⟨ id⟷₂ ⊡ (trans⟷₂ (resp⊕⟷₂ id⟷₁⊕id⟷₁⟷₂ id⟷₂ ⊡ id⟷₂) assoc◎l)  ⟩
+     assocl₊ ◎ ((id⟷₁ ⊕ tr0) ◎ (swap₊ ⊕ id⟷₁)) ◎ assocr₊
+       ⟷₂⟨ id⟷₂ ⊡ (hom◎⊕⟷₂ ⊡ id⟷₂)  ⟩
+     assocl₊ ◎ ((id⟷₁ ◎ swap₊) ⊕ (tr0 ◎ id⟷₁)) ◎ assocr₊
+       ⟷₂⟨ id⟷₂ ⊡ (trans⟷₂ (resp⊕⟷₂ idl◎l idr◎l) (resp⊕⟷₂ idr◎r idl◎r) ⊡ id⟷₂) ⟩
+     assocl₊ ◎ ((swap₊ ◎ id⟷₁) ⊕ (id⟷₁ ◎ tr0)) ◎ assocr₊
+       ⟷₂⟨  id⟷₂ ⊡ (hom⊕◎⟷₂ ⊡ id⟷₂)  ⟩
+     assocl₊ ◎ ((swap₊ ⊕ id⟷₁) ◎ (id⟷₁ ⊕ tr0)) ◎ assocr₊
+       ⟷₂⟨ id⟷₂ ⊡ ((id⟷₂ ⊡ resp⊕⟷₂ split⊕-id⟷₁ id⟷₂) ⊡ id⟷₂) ⟩
+     assocl₊ ◎ ((swap₊ ⊕ id⟷₁) ◎ ((id⟷₁ ⊕ id⟷₁) ⊕ tr0)) ◎ assocr₊
+       ⟷₂⟨ id⟷₂ ⊡ trans⟷₂ assoc◎r (id⟷₂ ⊡ assocr₊r) ⟩
+     assocl₊ ◎ (swap₊ ⊕ id⟷₁) ◎ assocr₊ ◎ (id⟷₁ ⊕ (id⟷₁ ⊕ tr0))
+       ⟷₂⟨ trans⟷₂ (id⟷₂ ⊡ assoc◎l) assoc◎l ⟩
+     (assocl₊ ◎ (swap₊ ⊕ id⟷₁) ◎ assocr₊) ◎ (id⟷₁ ⊕ (id⟷₁ ⊕ tr0)) ⟷₂∎
 slide-transpos {S m} (S n , np) (O , kp) (ltSR lp) = {!!}
 slide-transpos {S m} (S .(S (S k)) , np) (S k , kp) ltS = {!!}
 slide-transpos {S m} (S n , np) (S k , kp) (ltSR lp) = {!!}

--- a/Pi+/Level0.agda
+++ b/Pi+/Level0.agda
@@ -148,7 +148,7 @@ slide-transpos {S m} (S .(S (S k)) , np) (S k , kp) ltS =
     (trans⟷₂
       (resp⊕⟷₂ id⟷₂ (slide-transpos (S (S k) , <-cancel-S np) (k , <-cancel-S kp) ltS))
       hom⊕◎⟷₂)
-slide-transpos {S m} (S n , np) (S k , kp) (ltSR lp) = ?
+slide-transpos {S m} (S n , np) (S k , kp) (ltSR lp) = {!!}
 
 cox≈2pi : {m : ℕ} {r₁ r₂ : List (Fin (S m))} → r₁ ≈₁ r₂ → cox2pi r₁ ⟷₂ cox2pi r₂
 cox≈2pi (cancel {n}) =
@@ -161,7 +161,11 @@ cox≈2pi (cancel {n}) =
   id⟷₁ ⟷₂∎
 cox≈2pi (swap {n} {k} lp) =
   trans⟷₂ assoc◎l (trans⟷₂ (slide-transpos n k lp ⊡ id⟷₂) assoc◎r)
-cox≈2pi braid = {!!}
+cox≈2pi (braid {n}) =
+  transpos2pi S⟨ n ⟩ ◎ transpos2pi ⟨ n ⟩ ◎ transpos2pi S⟨ n ⟩ ◎ id⟷₁
+    ⟷₂⟨ {!!} ⟩
+  transpos2pi ⟨ n ⟩ ◎ transpos2pi S⟨ n ⟩ ◎ transpos2pi ⟨ n ⟩ ◎ id⟷₁ ⟷₂∎
+
 cox≈2pi idp = id⟷₂
 cox≈2pi (comm rw) = !⟷₂ (cox≈2pi rw)
 cox≈2pi (trans rw₁ rw₂) = trans⟷₂ (cox≈2pi rw₁) (cox≈2pi rw₂)

--- a/Pi+/Level0.agda
+++ b/Pi+/Level0.agda
@@ -60,6 +60,30 @@ eert = (F + (E + D)) + (C + (B + A))
 -----------------------------------------------------------------------------
 -- Special combinators on normal forms
 
+
+{--
+Better idea to explore:
+
+The normal form is a list; most of the combinators shift the focus around;
+the only real action is done by swap₊
+
+Given
+
+   x : ⟪ 6 ⟫
+   x = (A + (B + (C + (D + (E + (F + O))))))
+
+Want:
+
+   x[2] to have type ⟪ 2 +ℕ 4 ⟫
+   x[5] to have type ⟪ 5 +ℕ 1 ⟫
+   etc
+
+Perhaps use ideas from
+https://gist.github.com/beala/d9e95c17999e1cd4f2d9b8bddff7768a#file-cryptol-agda-L43
+
+--}
+
+
 data _⇔_ : (t₁ t₂ : U) → Set where
   id⇔ : {m : ℕ} → ⟪ m ⟫ ⇔ ⟪ m ⟫
   seq⇔ : {m n k : ℕ} → ⟪ m ⟫ ⇔ ⟪ n ⟫ → ⟪ n ⟫ ⇔ ⟪ k ⟫ → ⟪ m ⟫ ⇔ ⟪ k ⟫

--- a/Pi+/Level0.agda
+++ b/Pi+/Level0.agda
@@ -41,7 +41,14 @@ normC (t₁ + t₂) = (normC t₁ ⊕ normC t₂) ◎ ⟪++⟫
 -----------------------------------------------------------------------------
 -- Example
 
-postulate A B C D E F : U
+-- postulate A B C D E F : U
+A B C D E F : U
+A = I
+B = I
+C = I
+D = I
+E = I
+F = I
 
 tree eert : U
 tree = ((A + B) + C) + ((D + E) + F)
@@ -86,6 +93,54 @@ combNF id⟷₁ = id⇔
 combNF (c₁ ◎ c₂) = seq⇔ (combNF c₁) (combNF c₂)
 combNF (c₁ ⊕ c₂) = append⇔ (combNF c₁) (combNF c₂)
 
+-----------------------------------------------------------------------------
+-- Example ctd
+
+mirror : tree ⟷₁ eert
+mirror = swap₊ ◎ (swap₊ ⊕ swap₊) ◎ ((id⟷₁ ⊕ swap₊) ⊕ (id⟷₁ ⊕ swap₊))
+
+mirrorNF : canonU tree ⇔ canonU eert
+mirrorNF = combNF mirror
+
+{--
+Keeping A..F as postulates
+
+seq⇔
+  (bigSwap⇔ {∣ A ∣ +ℕ ∣ B ∣ +ℕ ∣ C ∣} {∣ D ∣ +ℕ ∣ E ∣ +ℕ ∣ F ∣})
+  (seq⇔
+    (append⇔
+      (bigSwap⇔ {∣ D ∣ +ℕ ∣ E ∣} {∣ F ∣})
+      (bigSwap⇔ {∣ A ∣ +ℕ ∣ B ∣} {∣ C ∣}))
+    (append⇔
+      (append⇔ id⇔
+        (bigSwap⇔ {∣ D ∣} {∣ E ∣}))
+      (append⇔ id⇔
+        (bigSwap⇔ {∣ A ∣} {∣ B ∣}))))
+
+A..F are all set to I
+
+seq⇔
+(seq⇔ snocN⇔
+ (seq⇔ assocr⇔
+  (seq⇔
+   (seq⇔ snocN⇔
+    (seq⇔ assocr⇔
+     (seq⇔ (seq⇔ snocN⇔ (seq⇔ assocr⇔ (seq⇔ unit⇔ assocr⇔))) assocr⇔)))
+   assocr⇔)))
+(seq⇔
+ (append⇔
+  (seq⇔ snocN⇔
+   (seq⇔ assocr⇔
+    (seq⇔ (seq⇔ snocN⇔ (seq⇔ assocr⇔ (seq⇔ unit⇔ assocr⇔))) assocr⇔)))
+  (seq⇔ snocN⇔
+   (seq⇔ assocr⇔
+    (seq⇔ (seq⇔ snocN⇔ (seq⇔ assocr⇔ (seq⇔ unit⇔ assocr⇔))) assocr⇔))))
+ (append⇔
+  (append⇔ id⇔ (seq⇔ snocN⇔ (seq⇔ assocr⇔ (seq⇔ unit⇔ assocr⇔))))
+  (append⇔ id⇔ (seq⇔ snocN⇔ (seq⇔ assocr⇔ (seq⇔ unit⇔ assocr⇔))))))
+--}
+
+-----------------------------------------------------------------------------
 -----------------------------------------------------------------------------
 
 {--

--- a/Pi+/Level0.agda
+++ b/Pi+/Level0.agda
@@ -110,12 +110,26 @@ cox2pi++ : {m : ℕ} → (l r : List (Fin (S m))) → cox2pi (l ++ r) ⟷₂ cox
 cox2pi++ nil r = idl◎r
 cox2pi++ (n :: l) r = trans⟷₂ (id⟷₂ ⊡ (cox2pi++ l r)) assoc◎l
 
-slide-transpos : {m : ℕ} → (n k : Fin (S m)) → (k<n : fst k < fst n) →
+slide-transpos : {m : ℕ} → (n k : Fin (S m)) → (Sk<n : S (fst k) < fst n) →
   transpos2pi n ◎ transpos2pi k ⟷₂ transpos2pi k ◎ transpos2pi n
-slide-transpos {O} (.0 , ltS) (.0 , ltS) ()
-slide-transpos {O} (.0 , ltS) (k , ltSR kp) ()
-slide-transpos {S m} (S n , np) (O , kp) _ = {!!}
-slide-transpos {S m} (S n , np) (S k , kp) k<n = {!!}
+slide-transpos {O} (O , np) (O , kp) ()
+slide-transpos {O} (O , np) (S k , kp) ()
+slide-transpos {O} (S .1 , ltSR ()) (O , kp) ltS
+slide-transpos {O} (S n , ltSR ()) (O , kp) (ltSR lp)
+slide-transpos {O} (S .(S (S k)) , ltSR ()) (S k , kp) ltS
+slide-transpos {O} (S n , np) (S k , ltSR ()) (ltSR lp)
+slide-transpos {S m} (O , np) (O , kp) ()
+slide-transpos {S m} (O , np) (S k , kp) ()
+slide-transpos {S m} (S .1 , np) (O , kp) ltS =
+  (id⟷₁ ⊕ (id⟷₁ ⊕ transpos2pi (0 , <-cancel-S (<-cancel-S np)))) ◎ (assocl₊ ◎ (swap₊ ⊕ id⟷₁) ◎ assocr₊)
+    ⟷₂⟨ {!!} ⟩
+  (assocl₊ ◎ ((id⟷₁ ⊕ id⟷₁) ⊕ transpos2pi (0 , <-cancel-S (<-cancel-S np)))) ◎
+  ((swap₊ ⊕ id⟷₁) ◎ assocr₊)
+    ⟷₂⟨ {!!} ⟩
+  (assocl₊ ◎ (swap₊ ⊕ id⟷₁) ◎ assocr₊) ◎ (id⟷₁ ⊕ (id⟷₁ ⊕ transpos2pi (0 , _))) ⟷₂∎
+slide-transpos {S m} (S n , np) (O , kp) (ltSR lp) = {!!}
+slide-transpos {S m} (S .(S (S k)) , np) (S k , kp) ltS = {!!}
+slide-transpos {S m} (S n , np) (S k , kp) (ltSR lp) = {!!}
 
 cox≈2pi : {m : ℕ} {r₁ r₂ : List (Fin (S m))} → r₁ ≈₁ r₂ → cox2pi r₁ ⟷₂ cox2pi r₂
 cox≈2pi (cancel {n}) =
@@ -126,29 +140,8 @@ cox≈2pi (cancel {n}) =
   id⟷₁ ◎ id⟷₁
     ⟷₂⟨ idl◎l ⟩
   id⟷₁ ⟷₂∎
-cox≈2pi (swap {O , np} {O , kp} ())
-cox≈2pi (swap {O , np} {S k , kp} ())
-cox≈2pi (swap {S .1 , np} {O , kp} ltS) = {!!}
-cox≈2pi (swap {S n , np} {O , kp} (ltSR lp)) = {!!}
-cox≈2pi (swap {S .(S (S k)) , np} {S k , kp} ltS) = {!!}
-cox≈2pi (swap {S n , np} {S k , kp} (ltSR lp)) = {!!}
-
---cox≈2pi (swap {S .1 , np} {O , kp} ltS) = {!!}
---cox≈2pi (swap {S n , np} {O , kp} (ltSR lp)) = {!!}
---cox≈2pi (swap {S .(S (S k)) , np} {S k , kp} ltS) = {!!}
---cox≈2pi (swap {S n , np} {S k , kp} (ltSR lp)) = {!!}
---  transpos2pi (S n , np) ◎ transpos2pi (k , kp) ◎ id⟷₁
---    ⟷₂⟨ id⟷₂ ⟩
---  (id⟷₁ ⊕ (transpos2pi (n , <-cancel-S np))) ◎ transpos2pi (k , kp) ◎ id⟷₁
---    ⟷₂⟨ {!!} ⟩
---  transpos2pi (k , kp) ◎ transpos2pi (S n , np) ◎ id⟷₁ ⟷₂∎
---
---cox≈2pi (swap {.(S (S k)) , SSk<Sm} {(k , k<Sm)} ltS) = {!!}
---cox≈2pi (swap {.(S _) , Sn<Sm} {(k , k<Sm)} (ltSR Sk<n)) = {!!}
---: cox2pi ((S (S k) , SSk<Sm) :: (k , k<Sm) :: nil) ⟷₂
---    cox2pi ((k , k<Sm) :: (S (S k) , SSk<Sm) :: nil)
---
---
+cox≈2pi (swap {n} {k} lp) =
+  trans⟷₂ assoc◎l (trans⟷₂ (slide-transpos n k lp ⊡ id⟷₂) assoc◎r)
 cox≈2pi braid = {!!}
 cox≈2pi idp = id⟷₂
 cox≈2pi (comm rw) = !⟷₂ (cox≈2pi rw)

--- a/Pi+/Level0.agda
+++ b/Pi+/Level0.agda
@@ -142,8 +142,13 @@ slide-transpos {S m} (S .1 , np) (O , kp) ltS =
        ⟷₂⟨ trans⟷₂ (id⟷₂ ⊡ assoc◎l) assoc◎l ⟩
      (assocl₊ ◎ (swap₊ ⊕ id⟷₁) ◎ assocr₊) ◎ (id⟷₁ ⊕ (id⟷₁ ⊕ tr0)) ⟷₂∎
 slide-transpos {S m} (S n , np) (O , kp) (ltSR lp) = {!!}
-slide-transpos {S m} (S .(S (S k)) , np) (S k , kp) ltS = {!!}
-slide-transpos {S m} (S n , np) (S k , kp) (ltSR lp) = {!!}
+slide-transpos {S m} (S .(S (S k)) , np) (S k , kp) ltS =
+  trans⟷₂
+    hom◎⊕⟷₂
+    (trans⟷₂
+      (resp⊕⟷₂ id⟷₂ (slide-transpos (S (S k) , <-cancel-S np) (k , <-cancel-S kp) ltS))
+      hom⊕◎⟷₂)
+slide-transpos {S m} (S n , np) (S k , kp) (ltSR lp) = ?
 
 cox≈2pi : {m : ℕ} {r₁ r₂ : List (Fin (S m))} → r₁ ≈₁ r₂ → cox2pi r₁ ⟷₂ cox2pi r₂
 cox≈2pi (cancel {n}) =

--- a/Pi+/Level0.agda
+++ b/Pi+/Level0.agda
@@ -126,19 +126,29 @@ cox≈2pi (cancel {n}) =
   id⟷₁ ◎ id⟷₁
     ⟷₂⟨ idl◎l ⟩
   id⟷₁ ⟷₂∎
-cox≈2pi (swap {(S n , np)} {(k , kp)} lp) =
-  transpos2pi (S n , np) ◎ transpos2pi (k , kp) ◎ id⟷₁
-    ⟷₂⟨ id⟷₂ ⟩
-  (id⟷₁ ⊕ (transpos2pi (n , <-cancel-S np))) ◎ transpos2pi (k , kp) ◎ id⟷₁
-    ⟷₂⟨ {!!} ⟩
-  transpos2pi (k , kp) ◎ transpos2pi (S n , np) ◎ id⟷₁ ⟷₂∎
+cox≈2pi (swap {O , np} {O , kp} ())
+cox≈2pi (swap {O , np} {S k , kp} ())
+cox≈2pi (swap {S .1 , np} {O , kp} ltS) = {!!}
+cox≈2pi (swap {S n , np} {O , kp} (ltSR lp)) = {!!}
+cox≈2pi (swap {S .(S (S k)) , np} {S k , kp} ltS) = {!!}
+cox≈2pi (swap {S n , np} {S k , kp} (ltSR lp)) = {!!}
 
+--cox≈2pi (swap {S .1 , np} {O , kp} ltS) = {!!}
+--cox≈2pi (swap {S n , np} {O , kp} (ltSR lp)) = {!!}
+--cox≈2pi (swap {S .(S (S k)) , np} {S k , kp} ltS) = {!!}
+--cox≈2pi (swap {S n , np} {S k , kp} (ltSR lp)) = {!!}
+--  transpos2pi (S n , np) ◎ transpos2pi (k , kp) ◎ id⟷₁
+--    ⟷₂⟨ id⟷₂ ⟩
+--  (id⟷₁ ⊕ (transpos2pi (n , <-cancel-S np))) ◎ transpos2pi (k , kp) ◎ id⟷₁
+--    ⟷₂⟨ {!!} ⟩
+--  transpos2pi (k , kp) ◎ transpos2pi (S n , np) ◎ id⟷₁ ⟷₂∎
+--
 --cox≈2pi (swap {.(S (S k)) , SSk<Sm} {(k , k<Sm)} ltS) = {!!}
 --cox≈2pi (swap {.(S _) , Sn<Sm} {(k , k<Sm)} (ltSR Sk<n)) = {!!}
 --: cox2pi ((S (S k) , SSk<Sm) :: (k , k<Sm) :: nil) ⟷₂
 --    cox2pi ((k , k<Sm) :: (S (S k) , SSk<Sm) :: nil)
-
-
+--
+--
 cox≈2pi braid = {!!}
 cox≈2pi idp = id⟷₂
 cox≈2pi (comm rw) = !⟷₂ (cox≈2pi rw)

--- a/Pi+/Level0.agda
+++ b/Pi+/Level0.agda
@@ -24,6 +24,32 @@ open import Pi+.Syntax
 canonU : U → U
 canonU t = ⟪ ∣ t ∣ ⟫
 
+--
+
+data UVec : (n : ℕ) → Set where
+  [] : UVec 0
+  X : {n : ℕ} → (nt : UVec n) → UVec (S n)
+
+tail : {n : ℕ} → UVec (S n) → UVec n
+tail (X nf) = nf
+
+data SplitUVec : {i j : ℕ} → UVec i → UVec j → Set where
+  here : {n : ℕ} {nf : UVec n} →
+         SplitUVec [] nf
+  skip : {i j : ℕ} {before : UVec i} {after : UVec (S j)} →
+         SplitUVec (X before) (tail after)
+
+⟦_⟧ : (n : ℕ) → UVec n
+⟦ 0 ⟧ = []
+⟦ S n ⟧ = X ⟦ n ⟧
+
+nfU : (t : U) → UVec ∣ t ∣
+nfU t = ⟦ ∣ t ∣ ⟧
+
+nf→canon : {m : ℕ} → UVec m → U
+nf→canon [] = O
+nf→canon (X nf) = I + nf→canon nf
+
 -----------------------------------------------------------------------------
 -- Converting Pi types to normal form
 
@@ -60,6 +86,20 @@ eert = (F + (E + D)) + (C + (B + A))
 -----------------------------------------------------------------------------
 -- Special combinators on normal forms
 
+-- Change to use SplitUVec...
+
+data _⇔_ : (t₁ t₂ : U) → Set where
+  id⇔ : {m : ℕ} → ⟪ m ⟫ ⇔ ⟪ m ⟫
+
+{--
+  seq⇔ : {m n k : ℕ} → ⟪ m ⟫ ⇔ ⟪ n ⟫ → ⟪ n ⟫ ⇔ ⟪ k ⟫ → ⟪ m ⟫ ⇔ ⟪ k ⟫
+  append⇔ : {m n k p : ℕ} → ⟪ m ⟫ ⇔ ⟪ k ⟫ → ⟪ n ⟫ ⇔ ⟪ p ⟫ →
+            ⟪ m +ℕ n ⟫ ⇔ ⟪ k +ℕ p ⟫
+  assocl⇔ : {m n k : ℕ} → ⟪ m +ℕ (n +ℕ k) ⟫ ⇔ ⟪ (m +ℕ n)  +ℕ k ⟫
+  assocr⇔ : {m n k : ℕ} → ⟪ (m +ℕ n) +ℕ k ⟫ ⇔ ⟪ m +ℕ (n +ℕ k) ⟫
+  snocN⇔ : {m : ℕ} → ⟪ 1 +ℕ m ⟫ ⇔ ⟪ m +ℕ 1 ⟫
+  unit⇔ : {m : ℕ} → ⟪ m ⟫ ⇔ ⟪ m +ℕ 0 ⟫
+--}
 
 {--
 Better idea to explore:
@@ -83,7 +123,7 @@ https://gist.github.com/beala/d9e95c17999e1cd4f2d9b8bddff7768a#file-cryptol-agda
 
 --}
 
-
+{--
 data _⇔_ : (t₁ t₂ : U) → Set where
   id⇔ : {m : ℕ} → ⟪ m ⟫ ⇔ ⟪ m ⟫
   seq⇔ : {m n k : ℕ} → ⟪ m ⟫ ⇔ ⟪ n ⟫ → ⟪ n ⟫ ⇔ ⟪ k ⟫ → ⟪ m ⟫ ⇔ ⟪ k ⟫
@@ -125,6 +165,9 @@ mirror = swap₊ ◎ (swap₊ ⊕ swap₊) ◎ ((id⟷₁ ⊕ swap₊) ⊕ (id�
 
 mirrorNF : canonU tree ⇔ canonU eert
 mirrorNF = combNF mirror
+
+--}
+
 
 {--
 Keeping A..F as postulates

--- a/Pi+/Level0.agda
+++ b/Pi+/Level0.agda
@@ -110,6 +110,13 @@ cox2pi++ : {m : ℕ} → (l r : List (Fin (S m))) → cox2pi (l ++ r) ⟷₂ cox
 cox2pi++ nil r = idl◎r
 cox2pi++ (n :: l) r = trans⟷₂ (id⟷₂ ⊡ (cox2pi++ l r)) assoc◎l
 
+slide-transpos : {m : ℕ} → (n k : Fin (S m)) → (k<n : fst k < fst n) →
+  transpos2pi n ◎ transpos2pi k ⟷₂ transpos2pi k ◎ transpos2pi n
+slide-transpos {O} (.0 , ltS) (.0 , ltS) ()
+slide-transpos {O} (.0 , ltS) (k , ltSR kp) ()
+slide-transpos {S m} (S n , np) (O , kp) _ = {!!}
+slide-transpos {S m} (S n , np) (S k , kp) k<n = {!!}
+
 cox≈2pi : {m : ℕ} {r₁ r₂ : List (Fin (S m))} → r₁ ≈₁ r₂ → cox2pi r₁ ⟷₂ cox2pi r₂
 cox≈2pi (cancel {n}) =
   transpos2pi n ◎ transpos2pi n ◎ id⟷₁
@@ -119,7 +126,19 @@ cox≈2pi (cancel {n}) =
   id⟷₁ ◎ id⟷₁
     ⟷₂⟨ idl◎l ⟩
   id⟷₁ ⟷₂∎
-cox≈2pi (swap lp) = {!!}
+cox≈2pi (swap {(S n , np)} {(k , kp)} lp) =
+  transpos2pi (S n , np) ◎ transpos2pi (k , kp) ◎ id⟷₁
+    ⟷₂⟨ id⟷₂ ⟩
+  (id⟷₁ ⊕ (transpos2pi (n , <-cancel-S np))) ◎ transpos2pi (k , kp) ◎ id⟷₁
+    ⟷₂⟨ {!!} ⟩
+  transpos2pi (k , kp) ◎ transpos2pi (S n , np) ◎ id⟷₁ ⟷₂∎
+
+--cox≈2pi (swap {.(S (S k)) , SSk<Sm} {(k , k<Sm)} ltS) = {!!}
+--cox≈2pi (swap {.(S _) , Sn<Sm} {(k , k<Sm)} (ltSR Sk<n)) = {!!}
+--: cox2pi ((S (S k) , SSk<Sm) :: (k , k<Sm) :: nil) ⟷₂
+--    cox2pi ((k , k<Sm) :: (S (S k) , SSk<Sm) :: nil)
+
+
 cox≈2pi braid = {!!}
 cox≈2pi idp = id⟷₂
 cox≈2pi (comm rw) = !⟷₂ (cox≈2pi rw)

--- a/Pi+/Util.agda
+++ b/Pi+/Util.agda
@@ -8,7 +8,7 @@ open import lib.types.Fin
 open import lib.types.Sigma
 open import lib.PathGroupoid
 
-open import Pi+.Syntax as Pi
+-- open import Pi+.Syntax as Pi
 open import Pi+.Level0
 
 -- swap i-th and j-th position

--- a/Pi+/Util.agda
+++ b/Pi+/Util.agda
@@ -8,7 +8,7 @@ open import lib.types.Fin
 open import lib.types.Sigma
 open import lib.PathGroupoid
 
--- open import Pi+.Syntax as Pi
+open import Pi+.Syntax as Pi
 open import Pi+.Level0
 
 -- swap i-th and j-th position


### PR DESCRIPTION
That's probably still not what you want, but here are some possible definitions of Coxter quotient.

Zeroth one is based on what we used to define HIT - for some reason it uses a custom `CList` type instead of HoTT `List`.
First one is the first one modified to use HoTT `List` and not use `w`.
Second one is not using any Fins, and instead encodes the knowledge in the explicit parameter, which from my perspective is somewhat easier to work with, but I'm not sure how this quotient should look like (it will be "global", e.g. (⋃_(n : ℕ) S_n) / ~, while the zeroth and first one are S_n / ~.