### PR TITLE
Refactored TODOs

### DIFF
--- a/Pi+/Coxeter/NonParametrized/ImpossibleLists.agda
+++ b/Pi+/Coxeter/NonParametrized/ImpossibleLists.agda
@@ -52,7 +52,7 @@ dec-long-lemma-rev : (n k n1 k1 : ℕ) -> (n1 ≤ k1) -> (l r : Listℕ) -> (n �
 dec-long-lemma-rev n (S (S k)) .(S n) .n pkn nil .(S (S n) ↑ k) idp = abs-refl pkn
 dec-long-lemma-rev n (S k) n1 k1 pkn (x ∷ l) r p = dec-long-lemma-rev (S n) k n1 k1 pkn l r (cut-head p)
 
--- TODO exact code duplication from incr-long-lemma
+-- nice to have: exact code duplication from incr-long-lemma
 dec-long-lemma : (n k n1 k1 : ℕ) -> (n1 ≤ k1) -> (l r : Listℕ) -> (n ↓ k) == (l ++ n1 ∷ k1 ∷ r) -> ⊥
 dec-long-lemma n k n1 k1 p l r q =
   let pp =

--- a/Pi+/Coxeter/NonParametrized/LehmerCanonical.agda
+++ b/Pi+/Coxeter/NonParametrized/LehmerCanonical.agda
@@ -26,7 +26,7 @@ canonical-append cl x px =
   in  lifted-m , start+end lifted-p idp
 
 lehmer-eta : {n : ℕ} -> {cl1 cl2 : Lehmer n} -> {r1 r2 : ℕ} -> (rn1 : r1 ≤ (S n)) -> (rn2 : r2 ≤ (S n)) -> (cl1 == cl2) -> (r1 == r2) -> (CanS cl1 rn1) == (CanS cl2 rn2)
-lehmer-eta rn1 rn2 idp idp = ap (CanS _) (prop-has-all-paths rn1 rn2) -- TODO: write with ap/uncurry, without path induction
+lehmer-eta rn1 rn2 idp idp = ap (CanS _) (prop-has-all-paths rn1 rn2) -- nice to have: write with ap/uncurry, without path induction
 
 final≅-↓ : (n k1 : ℕ) -> (m : Listℕ) -> (n ↓ k1) ≅ m -> ⊥
 final≅-↓ n k1 m (cancel≅ {n₁} l r .(n ↓ k1) .m defm defmf) = repeat-long-lemma n k1 n₁ l r defm

--- a/Pi+/Extra.agda
+++ b/Pi+/Extra.agda
@@ -3,4 +3,6 @@
 module Pi+.Extra where
 
 postulate
+  TODO! : ∀ {i} {A : Set i} → A
+  TODO- : ∀ {i} {A : Set i} → A
   TODO : ∀ {i} {A : Set i} → A

--- a/Pi+/Indexed/Equiv1.agda
+++ b/Pi+/Indexed/Equiv1.agda
@@ -73,70 +73,14 @@ pi^2list-!-nil {S n}
   rewrite (ℕ-p (+-assoc 0 0 1))
   rewrite (id-⊕-== {n = n}) = ap (map S⟨_⟩) ((ap (_++ nil) (++-unit-r _) ∙ ++-unit-r _) ∙ pi^2list-!-nil {n})
 
-module _ where
-  -- second possible proof of pi^2list-!-nil with a few TODOs
-  -- but if we won't need these lemmas, then we can just delete
-  -- the whole submodule below
-  ++^-id-! : (p : n == m) → ++^-id p == !⟷₁^ (++^-id (! p))
-  ++^-id-! idp = idp
+-- second possible proof of pi^2list-!-nil with a few things left out
+-- uses unfinished stuff from Equiv1NormHelpers.agda
 
-  ++^-⊕-id : (c : n ⟷₁^ m) → ++^-⊕ c id⟷₁^ ⟷₂^ transport2 (λ n' m' → n' ⟷₁^ m') (! (+-unit-r n)) (! (+-unit-r m)) c
-  ++^-⊕-id c = TODO
-
-  ++^-⊕-! : {n m o p : ℕ} → (c₁ : n ⟷₁^ m) → (c₂ : o ⟷₁^ p) → ++^-⊕ (!⟷₁^ c₁) (!⟷₁^ c₂) == !⟷₁^ (++^-⊕ c₁ c₂)
-  ++^-⊕-! {n} swap₊^ c₂ with (⟷₁^-eq-size (++^-⊕ (id⟷₁^ {n = n}) (!⟷₁^ c₂)))
-  ... | q =  TODO
-  ++^-⊕-! {O} id⟷₁^ c₂ = idp
-  ++^-⊕-! {S n} id⟷₁^ c₂ = ap ⊕^_ (++^-⊕-! {n} id⟷₁^ c₂)
-  ++^-⊕-! (c₁ ◎^ c₂) c₃ = 
-    let r₁ = ++^-⊕-! c₁ id⟷₁^
-        r₂ = ++^-⊕-! c₂ c₃
-    in  ap2 _◎^_ r₂ r₁ ∙ TODO
-  ++^-⊕-! (⊕^ c₁) c₂ = ap ⊕^_ (++^-⊕-! c₁ c₂)
-
-  ++^-swap-! : {n m : ℕ} → ++^-swap m n == !⟷₁^ (++^-swap n m)
-  ++^-swap-! {n} {m} = TODO
-
-  eval^₁-! : {t₁ : U n} → {t₂ : U m} → (c : t₁ ⟷₁ t₂) → eval^₁ (!⟷₁ c) == !⟷₁^ (eval^₁ c)
-  eval^₁-! unite₊l = idp
-  eval^₁-! uniti₊l = idp
-  eval^₁-! (swap₊ {n} {_} {m} {_}) = ++^-swap-! {n} {m}
-  eval^₁-! assocl₊ = ++^-id-! _
-  eval^₁-! assocr₊ = ++^-id-! _ ∙ ap (λ x → !⟷₁^ (++^-id x)) (!-! _)
-  eval^₁-! id⟷₁ = idp
-  eval^₁-! (c₁ ◎ c₂) = 
-    let r₁ = eval^₁-! c₁
-        r₂ = eval^₁-! c₂
-    in  ap2 (λ c₁' c₂' → c₁' ◎^ c₂') r₂ r₁
-  eval^₁-! (c₁ ⊕ c₂) = 
-    let r₁ = eval^₁-! c₁
-        r₂ = eval^₁-! c₂
-    in  ap2 ++^-⊕ r₁ r₂ ∙ ++^-⊕-! (eval^₁ c₁) (eval^₁ c₂)
-
-  reverse-++ : ∀ {i} {A : Type i} → (l₁ l₂ : List A) → reverse (l₁ ++ l₂) == (reverse l₂) ++ (reverse l₁)
-  reverse-++ nil l₂ = ! (++-unit-r _)
-  reverse-++ (x :: l₁) l₂ = 
-    let r = reverse-++ l₁ l₂
-    in  ap (λ l → snoc l x) r ∙ ++-assoc (reverse l₂) (reverse l₁) (x :: nil)
-
-  pi^2list-! : (c : (S n) ⟷₁^ (S m)) → pi^2list (!⟷₁^ c) == transport (λ k → List (Fin k)) (ℕ-S-is-inj _ _ (⟷₁^-eq-size c)) (reverse (pi^2list c))
-  pi^2list-! swap₊^ = idp
-  pi^2list-! id⟷₁^ = idp
-  pi^2list-! (c₁ ◎^ c₂) with (⟷₁^-eq-size c₁) with (⟷₁^-eq-size c₂)
-  ... | idp | idp = 
-    let r₁ = pi^2list-! c₁
-        r₂ = pi^2list-! c₂
-    in  ap2 (λ l₁ l₂ → l₁ ++ l₂) r₂ r₁ ∙ ! (reverse-++ (pi^2list c₁) (pi^2list c₂))
-  pi^2list-! {O} (⊕^ c) with (⟷₁^-eq-size c)
-  ... | idp = idp
-  pi^2list-! {S n} (⊕^ c) with (⟷₁^-eq-size c)
-  ... | idp = ap (map S⟨_⟩) (pi^2list-! c) ∙ ! (reverse-map S⟨_⟩ (pi^2list c))
-
-  pi^2list-!-nil' : pi^2list (⊕^ eval^₁ (!⟷₁ (quote-eval^₀ (quote^₀ n)))) == nil
-  pi^2list-!-nil' {n} =
-    ap (λ x → pi^2list (⊕^ x)) (eval^₁-! (quote-eval^₀ (quote^₀ n))) ∙
-    pi^2list-! (⊕^ (eval^₁ (quote-eval^₀ (quote^₀ n)))) ∙ 
-    transport (λ e → transport (λ k → List (Fin k)) e (reverse (pi^2list (⊕^ eval^₁ (quote-eval^₀ (quote^₀ n))))) == nil) (ℕ-p idp) (ap reverse pi^2list-nil)
+-- pi^2list-!-nil' : pi^2list (⊕^ eval^₁ (!⟷₁ (quote-eval^₀ (quote^₀ n)))) == nil
+-- pi^2list-!-nil' {n} =
+--   ap (λ x → pi^2list (⊕^ x)) (eval^₁-! (quote-eval^₀ (quote^₀ n))) ∙
+--   pi^2list-! (⊕^ (eval^₁ (quote-eval^₀ (quote^₀ n)))) ∙ 
+--   transport (λ e → transport (λ k → List (Fin k)) e (reverse (pi^2list (⊕^ eval^₁ (quote-eval^₀ (quote^₀ n))))) == nil) (ℕ-p idp) (ap reverse pi^2list-nil)
 
 
 eval-quote₁ : (e : Aut (Fin n)) → (eval₁ {t₁ = (quote₀ (pFin _))} {t₂ = (quote₀ (pFin _))} (quote₁ idp e)) == e
@@ -164,7 +108,7 @@ quote-eval²₀ {O} t = id⟷₂
 quote-eval²₀ {S n} t =
   let rec = quote-eval²₀ {n} (quote₀ (pFin _))
   in  _ ⟷₂⟨ id⟷₂ ⊡ resp⊕⟷₂ id⟷₂ rec ⟩
-      _ ⟷₂⟨ TODO ⟩ -- Goal: (((id⟷₁ ⊕ uniti₊l) ◎ assocl₊) ◎ unite₊r ⊕ id⟷₁) ⟷₂ id⟷₁
+      _ ⟷₂⟨ TODO! ⟩ -- Goal: (((id⟷₁ ⊕ uniti₊l) ◎ assocl₊) ◎ unite₊r ⊕ id⟷₁) ⟷₂ id⟷₁
       _ ⟷₂∎
 
 quote-eval₁ : {t₁ : U n} {t₂ : U m} → (c : t₁ ⟷₁ t₂) → (quote₁ (⟷₁-eq-size c) (eval₁ c)) ⟷₂ denorm c

--- a/Pi+/Indexed/Equiv1Hat.agda
+++ b/Pi+/Indexed/Equiv1Hat.agda
@@ -98,10 +98,10 @@ quote-eval^₁ swap₊ = !⟷₂ (
     _ ⟷₂⟨ id⟷₂ ⊡ assoc◎l ⟩
     _ ⟷₂⟨ id⟷₂ ⊡ (linv◎l ⊡ id⟷₂) ⟩
     _ ⟷₂⟨ id⟷₂ ⊡ idl◎l ⟩
-    _ ⟷₂⟨ TODO ⟩
+    _ ⟷₂⟨ TODO! ⟩
     _ ⟷₂∎)
-quote-eval^₁ (assocl₊ {n} {_} {m} {_} {o} {_}) = TODO
-quote-eval^₁ assocr₊ = TODO
+quote-eval^₁ (assocl₊ {n} {_} {m} {_} {o} {_}) = TODO!
+quote-eval^₁ assocr₊ = TODO!
 quote-eval^₁ id⟷₁ = linv◎r ■ (id⟷₂ ⊡ idl◎r)
 quote-eval^₁ (c₁ ◎ c₂) =
     let r₁ = quote-eval^₁ c₁
@@ -115,5 +115,5 @@ quote-eval^₁ (c₁ ⊕ c₂) =
     in !⟷₂ (
        _ ⟷₂⟨ denorm-⊕-β _ _ ⟩
        _ ⟷₂⟨ (id⟷₂ ⊡ (resp⊕⟷₂ r₁ r₂ ⊡ id⟷₂)) ⟩
-       _ ⟷₂⟨ TODO ⟩
+       _ ⟷₂⟨ TODO! ⟩
        _ ⟷₂∎)

--- a/Pi+/Indexed/Equiv1NormHelpers.agda
+++ b/Pi+/Indexed/Equiv1NormHelpers.agda
@@ -122,14 +122,62 @@ eval₁-map-S ((x , xp) :: l) rewrite <-has-all-paths (<-cancel-S (<-ap-S xp)) x
 pi^2list-◎^-β : {c₁ c₂ : S n ⟷₁^ S n} → pi^2list (c₁ ◎^ c₂) == pi^2list c₁ ++ pi^2list c₂
 pi^2list-◎^-β = idp
 
-pi^2list-!-β : {c : S n ⟷₁^ S n} → pi^2list (!⟷₁^ c) == reverse (pi^2list c)
-pi^2list-!-β {O} {id⟷₁^} = idp
-pi^2list-!-β {O} {c₁ ◎^ c₂} with (⟷₁^-eq-size c₁)
-... | idp = ap (λ l → l ++ pi^2list (!⟷₁^ c₁)) (pi^2list-!-β {c = c₂})
-          ∙ ap (λ l → reverse (pi^2list c₂) ++ l) (pi^2list-!-β {c = c₁})
-          ∙ TODO
-pi^2list-!-β {O} {⊕^ c} = TODO
-pi^2list-!-β {S n} {c} = TODO
+module _ where
+  ++^-id-! : (p : n == m) → ++^-id p == !⟷₁^ (++^-id (! p))
+  ++^-id-! idp = idp
+
+  ++^-⊕-id : (c : n ⟷₁^ m) → ++^-⊕ c id⟷₁^ ⟷₂^ transport2 (λ n' m' → n' ⟷₁^ m') (! (+-unit-r n)) (! (+-unit-r m)) c
+  ++^-⊕-id c = TODO-
+
+  ++^-⊕-! : {n m o p : ℕ} → (c₁ : n ⟷₁^ m) → (c₂ : o ⟷₁^ p) → ++^-⊕ (!⟷₁^ c₁) (!⟷₁^ c₂) == !⟷₁^ (++^-⊕ c₁ c₂)
+  ++^-⊕-! {n} swap₊^ c₂ with (⟷₁^-eq-size (++^-⊕ (id⟷₁^ {n = n}) (!⟷₁^ c₂)))
+  ... | q =  TODO-
+  ++^-⊕-! {O} id⟷₁^ c₂ = idp
+  ++^-⊕-! {S n} id⟷₁^ c₂ = ap ⊕^_ (++^-⊕-! {n} id⟷₁^ c₂)
+  ++^-⊕-! (c₁ ◎^ c₂) c₃ = 
+    let r₁ = ++^-⊕-! c₁ id⟷₁^
+        r₂ = ++^-⊕-! c₂ c₃
+    in  ap2 _◎^_ r₂ r₁ ∙ TODO-
+  ++^-⊕-! (⊕^ c₁) c₂ = ap ⊕^_ (++^-⊕-! c₁ c₂)
+
+  ++^-swap-! : {n m : ℕ} → ++^-swap m n == !⟷₁^ (++^-swap n m)
+  ++^-swap-! {n} {m} = TODO-
+
+  eval^₁-! : {t₁ : U n} → {t₂ : U m} → (c : t₁ ⟷₁ t₂) → eval^₁ (!⟷₁ c) == !⟷₁^ (eval^₁ c)
+  eval^₁-! unite₊l = idp
+  eval^₁-! uniti₊l = idp
+  eval^₁-! (swap₊ {n} {_} {m} {_}) = ++^-swap-! {n} {m}
+  eval^₁-! assocl₊ = ++^-id-! _
+  eval^₁-! assocr₊ = ++^-id-! _ ∙ ap (λ x → !⟷₁^ (++^-id x)) (!-! _)
+  eval^₁-! id⟷₁ = idp
+  eval^₁-! (c₁ ◎ c₂) = 
+    let r₁ = eval^₁-! c₁
+        r₂ = eval^₁-! c₂
+    in  ap2 (λ c₁' c₂' → c₁' ◎^ c₂') r₂ r₁
+  eval^₁-! (c₁ ⊕ c₂) = 
+    let r₁ = eval^₁-! c₁
+        r₂ = eval^₁-! c₂
+    in  ap2 ++^-⊕ r₁ r₂ ∙ ++^-⊕-! (eval^₁ c₁) (eval^₁ c₂)
+
+  reverse-++ : ∀ {i} {A : Type i} → (l₁ l₂ : List A) → reverse (l₁ ++ l₂) == (reverse l₂) ++ (reverse l₁)
+  reverse-++ nil l₂ = ! (++-unit-r _)
+  reverse-++ (x :: l₁) l₂ = 
+    let r = reverse-++ l₁ l₂
+    in  ap (λ l → snoc l x) r ∙ ++-assoc (reverse l₂) (reverse l₁) (x :: nil)
+
+  pi^2list-!^-β : (c : (S n) ⟷₁^ (S m)) → pi^2list (!⟷₁^ c) == transport (λ k → List (Fin k)) (ℕ-S-is-inj _ _ (⟷₁^-eq-size c)) (reverse (pi^2list c))
+  pi^2list-!^-β swap₊^ = idp
+  pi^2list-!^-β id⟷₁^ = idp
+  pi^2list-!^-β (c₁ ◎^ c₂) with (⟷₁^-eq-size c₁) with (⟷₁^-eq-size c₂)
+  ... | idp | idp = 
+    let r₁ = pi^2list-!^-β c₁
+        r₂ = pi^2list-!^-β c₂
+    in  ap2 (λ l₁ l₂ → l₁ ++ l₂) r₂ r₁ ∙ ! (reverse-++ (pi^2list c₁) (pi^2list c₂))
+  pi^2list-!^-β {O} (⊕^ c) with (⟷₁^-eq-size c)
+  ... | idp = idp
+  pi^2list-!^-β {S n} (⊕^ c) with (⟷₁^-eq-size c)
+  ... | idp = ap (map S⟨_⟩) (pi^2list-!^-β c) ∙ ! (reverse-map S⟨_⟩ (pi^2list c))
+
 
 pi^2list2pi^ : (c : S n ⟷₁^ S m) →
     (list2pi^I (ℕ-S-is-inj _ _ (⟷₁^-eq-size c)) (pi^2list c)) ⟷₂^ c

--- a/Pi+/Indexed/Equiv2Hat.agda
+++ b/Pi+/Indexed/Equiv2Hat.agda
@@ -28,42 +28,42 @@ eval^₂ : {t₁ : U n} {t₂ : U m} {c₁ c₂ : t₁ ⟷₁ t₂} → c₁ ⟷
 eval^₂ assoc◎l = assoc◎l^
 eval^₂ assoc◎r = assoc◎r^
 eval^₂ (assocl₊l {n₁} {_} {n₂} {_} {n₃} {_} {n₄} {_} {n₅} {_} {n₆} {_}) with (N.+-assoc n₂ n₄ n₆) | (N.+-assoc n₁ n₃ n₅)
-... | p | q = TODO
-eval^₂ assocl₊r = TODO
-eval^₂ assocr₊r = TODO
-eval^₂ assocr₊l = TODO
+... | p | q = TODO!
+eval^₂ assocl₊r = TODO!
+eval^₂ assocr₊r = TODO!
+eval^₂ assocr₊l = TODO!
 eval^₂ idl◎l = idl◎l^
 eval^₂ idl◎r = idl◎r^
 eval^₂ idr◎l = idr◎l^
 eval^₂ idr◎r = idr◎r^
-eval^₂ linv◎l = TODO
-eval^₂ linv◎r = TODO
-eval^₂ rinv◎l = TODO
-eval^₂ rinv◎r = TODO
-eval^₂ unite₊l⟷₂l = TODO
-eval^₂ unite₊l⟷₂r = TODO
-eval^₂ uniti₊l⟷₂l = TODO
-eval^₂ uniti₊l⟷₂r = TODO
-eval^₂ swapl₊⟷₂ = TODO
-eval^₂ swapr₊⟷₂ = TODO
+eval^₂ linv◎l = TODO!
+eval^₂ linv◎r = TODO!
+eval^₂ rinv◎l = TODO!
+eval^₂ rinv◎r = TODO!
+eval^₂ unite₊l⟷₂l = TODO!
+eval^₂ unite₊l⟷₂r = TODO!
+eval^₂ uniti₊l⟷₂l = TODO!
+eval^₂ uniti₊l⟷₂r = TODO!
+eval^₂ swapl₊⟷₂ = TODO!
+eval^₂ swapr₊⟷₂ = TODO!
 eval^₂ id⟷₂ = id⟷₂^
 eval^₂ (_■_ α₁ α₂) = _■^_ (eval^₂ α₁) (eval^₂ α₂)
 eval^₂ (α₁ ⊡ α₂) = eval^₂ α₁ ⊡^ eval^₂ α₂
-eval^₂ (resp⊕⟷₂ α₁ α₂) = TODO
-eval^₂ id⟷₁⊕id⟷₁⟷₂ = TODO
-eval^₂ split⊕-id⟷₁ = TODO
-eval^₂ hom⊕◎⟷₂ = TODO
-eval^₂ hom◎⊕⟷₂ = TODO
-eval^₂ triangle₊l = TODO
-eval^₂ triangle₊r = TODO
-eval^₂ pentagon₊l = TODO
-eval^₂ pentagon₊r = TODO
-eval^₂ unite₊l-coh-l = TODO
-eval^₂ unite₊l-coh-r = TODO
-eval^₂ hexagonr₊l = TODO
-eval^₂ hexagonr₊r = TODO
-eval^₂ hexagonl₊l = TODO
-eval^₂ hexagonl₊r = TODO
+eval^₂ (resp⊕⟷₂ α₁ α₂) = TODO!
+eval^₂ id⟷₁⊕id⟷₁⟷₂ = TODO!
+eval^₂ split⊕-id⟷₁ = TODO!
+eval^₂ hom⊕◎⟷₂ = TODO!
+eval^₂ hom◎⊕⟷₂ = TODO!
+eval^₂ triangle₊l = TODO!
+eval^₂ triangle₊r = TODO!
+eval^₂ pentagon₊l = TODO!
+eval^₂ pentagon₊r = TODO!
+eval^₂ unite₊l-coh-l = TODO!
+eval^₂ unite₊l-coh-r = TODO!
+eval^₂ hexagonr₊l = TODO!
+eval^₂ hexagonr₊r = TODO!
+eval^₂ hexagonl₊l = TODO!
+eval^₂ hexagonl₊r = TODO!
 
 !-quote^₁ : (c : n ⟷₁^ m) → quote^₁ (!⟷₁^ c) ⟷₂ !⟷₁ (quote^₁ c)
 !-quote^₁ swap₊^ = assoc◎l
@@ -110,7 +110,7 @@ quote^₂ (swapl₊⟷₂^ {c = c}) =
 quote^₂ hexagonl₊l =
     let s₁ = assocl₊ ◎ (swap₊ ⊕ id⟷₁) ◎ assocr₊
         s₂ = assocl₊ ◎ (swap₊ ⊕ id⟷₁) ◎ assocr₊
-    in  s₁ ◎ (id⟷₁ ⊕ s₂) ◎ s₁ ⟷₂⟨ TODO ⟩
+    in  s₁ ◎ (id⟷₁ ⊕ s₂) ◎ s₁ ⟷₂⟨ TODO! ⟩
         (id⟷₁ ⊕ s₂) ◎ s₁ ◎ (id⟷₁ ⊕ s₂) ⟷₂∎
 quote^₂ hexagonl₊r = 
     let r = (quote^₂ hexagonl₊l)

--- a/Pi+/Indexed/Equiv2Norm.agda
+++ b/Pi+/Indexed/Equiv2Norm.agda
@@ -52,31 +52,31 @@ module _ {c₁ c₂ : S n ⟷₁^ m} where
   evalNorm₂-S idr◎r^ with (⟷₁^-eq-size c₂)
   ... | idp = ap (<– Fin≃Lehmer ∘ immersion⁻¹) (! (++-unit-r (pi^2list c₁)))
   evalNorm₂-S (linv◎l^ {c = c}) with (⟷₁^-eq-size c)
-  ... | idp = TODO
+  ... | idp = TODO!
   evalNorm₂-S (linv◎r^ {c = c}) with (⟷₁^-eq-size c)
-  ... | idp = TODO
+  ... | idp = TODO!
   evalNorm₂-S (rinv◎l^ {c = c}) with (⟷₁^-eq-size c)
-  ... | idp = TODO
+  ... | idp = TODO!
   evalNorm₂-S (rinv◎r^ {c = c}) with (⟷₁^-eq-size c)
-  ... | idp = TODO
+  ... | idp = TODO!
   evalNorm₂-S id⟷₂^ = idp
   evalNorm₂-S (_■^_ α₁ α₂) with (⟷₁^-eq-size c₁) | (⟷₁^-eq-size c₂)
-  ... | idp | q rewrite loop-η q = TODO
+  ... | idp | q rewrite loop-η q = TODO!
   evalNorm₂-S (_⊡^_ {c₁ = c₁} {c₂ = c₂} {c₃ = c₃} {c₄ = c₄} α_₁ α₂) with (⟷₁^-eq-size c₁) | (⟷₁^-eq-size c₂) | (⟷₁^-eq-size c₃) | (⟷₁^-eq-size c₄)
-  ... | idp | idp | p | q rewrite loop-η p rewrite loop-η q = TODO
+  ... | idp | idp | p | q rewrite loop-η p rewrite loop-η q = TODO!
   evalNorm₂-S (⊕id⟷₁⟷₂^ {n = O}) = idp
-  evalNorm₂-S (⊕id⟷₁⟷₂^ {n = S n}) = e= λ { (O , p) → idp ; (S n , p) → TODO }
+  evalNorm₂-S (⊕id⟷₁⟷₂^ {n = S n}) = e= λ { (O , p) → idp ; (S n , p) → TODO! }
   evalNorm₂-S (!⊕id⟷₁⟷₂^ {n = O}) = idp
-  evalNorm₂-S (!⊕id⟷₁⟷₂^ {n = S n}) = e= λ { (O , p) → idp ; (S n , p) → TODO }
-  evalNorm₂-S hom◎⊕⟷₂^ = TODO
+  evalNorm₂-S (!⊕id⟷₁⟷₂^ {n = S n}) = e= λ { (O , p) → idp ; (S n , p) → TODO! }
+  evalNorm₂-S hom◎⊕⟷₂^ = TODO!
   evalNorm₂-S (resp⊕⟷₂ {c₁ = c₁} {c₂ = c₂} α) with (⟷₁^-eq-size c₁) | (⟷₁^-eq-size c₂)
-  ... | idp | q rewrite loop-η q = TODO
+  ... | idp | q rewrite loop-η q = TODO!
   evalNorm₂-S (hom⊕◎⟷₂^ {c₁ = c₁} {c₂ = c₂}) with (⟷₁^-eq-size c₁) | (⟷₁^-eq-size c₂)
-  ... | idp | idp = TODO
-  evalNorm₂-S (swapr₊⟷₂^ {n = O}) = e= λ { (O , p) → idp ; (S n , p) → TODO }
-  evalNorm₂-S (swapr₊⟷₂^ {n = S n}) = e= λ { (O , p) → TODO ; (S n , p) → TODO }
-  evalNorm₂-S (swapl₊⟷₂^ {n = O}) = e= λ { (O , p) → idp ; (S n , p) → TODO }
-  evalNorm₂-S (swapl₊⟷₂^ {n = S n}) = e= λ { (O , p) → TODO ; (S n , p) → TODO }
+  ... | idp | idp = TODO!
+  evalNorm₂-S (swapr₊⟷₂^ {n = O}) = e= λ { (O , p) → idp ; (S n , p) → TODO! }
+  evalNorm₂-S (swapr₊⟷₂^ {n = S n}) = e= λ { (O , p) → TODO! ; (S n , p) → TODO! }
+  evalNorm₂-S (swapl₊⟷₂^ {n = O}) = e= λ { (O , p) → idp ; (S n , p) → TODO! }
+  evalNorm₂-S (swapl₊⟷₂^ {n = S n}) = e= λ { (O , p) → TODO! ; (S n , p) → TODO! }
   evalNorm₂-S (hexagonl₊l {n = O}) = e= λ { (O , p) → idp ; (S n , p) → idp }
   evalNorm₂-S (hexagonl₊l {n = S n}) = e= λ { (O , p) → idp ; (S n , p) → idp }
   evalNorm₂-S (hexagonl₊r {n = O}) = e= λ { (O , p) → idp ; (S n , p) → idp }

--- a/Pi+/Indexed/Syntax.agda
+++ b/Pi+/Indexed/Syntax.agda
@@ -271,16 +271,16 @@ _ ⟷₂∎ = id⟷₂
 !⟷₁⟷₂ hom◎⊕⟷₂ = hom◎⊕⟷₂
 !⟷₁⟷₂ triangle₊l =
   ((uniti₊l ◎ swap₊) ⊕ id⟷₁)
-    ⟷₂⟨ TODO ⟩
+    ⟷₂⟨ TODO! ⟩
   ((id⟷₁ ⊕ uniti₊l) ◎ assocl₊) ⟷₂∎
 !⟷₁⟷₂ triangle₊r =
   ((id⟷₁ ⊕ uniti₊l) ◎ assocl₊)
-    ⟷₂⟨ TODO ⟩
+    ⟷₂⟨ TODO! ⟩
   ((uniti₊l ◎ swap₊) ⊕ id⟷₁) ⟷₂∎
-!⟷₁⟷₂ pentagon₊l = TODO
-!⟷₁⟷₂ pentagon₊r = TODO
-!⟷₁⟷₂ unite₊l-coh-l = TODO
-!⟷₁⟷₂ unite₊l-coh-r = TODO
+!⟷₁⟷₂ pentagon₊l = TODO!
+!⟷₁⟷₂ pentagon₊r = TODO!
+!⟷₁⟷₂ unite₊l-coh-l = TODO!
+!⟷₁⟷₂ unite₊l-coh-r = TODO!
 !⟷₁⟷₂ hexagonr₊l = _■_ (_■_ assoc◎l hexagonl₊l) assoc◎r
 !⟷₁⟷₂ hexagonr₊r = _■_ (_■_ assoc◎l hexagonl₊r) assoc◎r
 !⟷₁⟷₂ hexagonl₊l = _■_ (_■_ assoc◎l hexagonr₊l) assoc◎r

--- a/Pi+/Misc.agda
+++ b/Pi+/Misc.agda
@@ -52,16 +52,16 @@ inspect x = x with== idp
 
 ∘e-assoc : {A B C D : Type₀} → (ab : A ≃ B) → (bc : B ≃ C) → (cd : C ≃ D)
   → (cd ∘e (bc ∘e ab)) == (cd ∘e bc) ∘e ab
-∘e-assoc ab bc cd = TODO
+∘e-assoc ab bc cd = TODO!
 
 ∘e-inv-r : {A B : Type₀} → (e : A ≃ B) → (e ∘e e ⁻¹) == (ide B)
-∘e-inv-r e = TODO
+∘e-inv-r e = TODO!
 
 ∘e-unit-r : {A B : Type₀} → (e : A ≃ B) → ((ide B) ∘e e) == e
-∘e-unit-r e = TODO
+∘e-unit-r e = TODO!
 
 ∘e-inv-l : {A B : Type₀} → (e : A ≃ B) → (e ⁻¹ ∘e e) == (ide A)
-∘e-inv-l e = TODO
+∘e-inv-l e = TODO!
 
 -- post∘-equiv
 
@@ -78,7 +78,7 @@ cong≃ bc = equiv f g f-g g-f
     g-f x = ∘e-assoc x bc (bc ⁻¹) ∙ ap (λ e → e ∘e x) (∘e-inv-l bc) ∙ ∘e-unit-r x
 
 double⁻¹ : {A B : Type₀} → (x : A ≃ B) → (x ⁻¹ ⁻¹) == x
-double⁻¹ x = pair= idp TODO
+double⁻¹ x = pair= idp TODO!
 
 !≃ : {A B C D : Type₀} → (A ≃ B) ≃ (C ≃ D) → (B ≃ A) ≃ (D ≃ C)
 !≃ (f , record { g = g ; f-g = f-g ; g-f = g-f ; adj = adj }) = equiv ff gg ff-gg gg-ff

--- a/Pi+/NonIndexed/Equiv1.agda
+++ b/Pi+/NonIndexed/Equiv1.agda
@@ -98,4 +98,4 @@ quote-eval₁ {X} {Y} p =
     in  quoted⟷₂norm
 
 eval-quote₁ : {X Y : UFin} → (p : X == Y) → eval₁ (quote₁ p) == ap (λ X → eval₀ (quote₀ X)) p
-eval-quote₁ p = TODO
+eval-quote₁ p = TODO-

--- a/Pi+/NonIndexed/Equiv2.agda
+++ b/Pi+/NonIndexed/Equiv2.agda
@@ -19,7 +19,7 @@ open import lib.types.SetQuotient
 open import lib.types.Coproduct
 
 eval₂ : {X Y : U} {p q : X ⟷₁ Y } → p ⟷₂ q → eval₁ p == eval₁ q
-eval₂ {p = p} {q = q} α = TODO
+eval₂ {p = p} {q = q} α = TODO-
 
 quote₂ : {X Y : UFin} {p q : X == Y} (α : p == q) → quote₁ p ⟷₂ quote₁ q
 quote₂ {p = p} {q = q} α = transport (λ e → quote₁ p ⟷₂ quote₁ e) α id⟷₂

--- a/Pi+/UFinLehmerEquiv.agda
+++ b/Pi+/UFinLehmerEquiv.agda
@@ -20,9 +20,9 @@ module _ {n : ℕ} where
             g : ΩBAut (Fin n) → Ω ⊙[ UFin , FinFS n ]
             g p = pair= (fst= p) prop-has-all-paths-↓
             f-g : (p : ΩBAut (Fin n)) → f (g p) == p
-            f-g p = TODO
+            f-g p = TODO-
             g-f : (p : Ω ⊙[ UFin , FinFS n ]) → g (f p) == p
-            g-f p = TODO
+            g-f p = TODO-
 
     UFin≃Fin : Ω ⊙[ UFin , FinFS n ] ≃ Aut (Fin n)
     UFin≃Fin = Fin-loop-equiv n ∘e UFin≃BAut

--- a/Pi+/temp_TODO.md
+++ b/Pi+/temp_TODO.md
@@ -1,4 +1,4 @@
-TODO (Pi part):
+(Pi part):
 
  1. Prove the big-id thing
  2. Port the Equiv2.agda to the same structure of ^, Norm etc.


### PR DESCRIPTION
`TODO`s are refactored into two kinds: 
 - `TODO!` - essential ones
 - `TODO-` - non-essential ones

We can now just `grep "TODO\!"` and if we fill all of them, the proof is finished.

**The convention is that all new `TODO`s are `TODO!`, and only after proving it some other way, it can be turned into `TODO-`.**

I didn't touch the FSMG stuff, which uses normal `TODO` as before.